### PR TITLE
build: require libcpprest-dev for non-npu builds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ git submodule update
 #### Compilation
 compile xllm-service: 
 ```bash
-sh prepare.sh # apply patch
+# prepare.sh checks libcpprest-dev, installs it only when running as root on Debian/Ubuntu,
+# and then applies the cpprestsdk patch. Otherwise install libcpprest-dev manually first.
+sh prepare.sh
 mkdir -p build && cd build
 cmake .. && make -j 8
 ```

--- a/README_zh.md
+++ b/README_zh.md
@@ -67,7 +67,9 @@ git submodule update
 #### 编译
 编译执行
 ```bash
-sh prepare.sh # 应用patch
+# prepare.sh 会检查 libcpprest-dev；在 Debian/Ubuntu root 环境中缺失时自动安装，
+# 否则请先手动安装 libcpprest-dev，然后脚本会应用 cpprestsdk patch。
+sh prepare.sh
 mkdir -p build && cd build
 cmake .. && make -j 8
 ```

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,2 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+# The vendored etcd-cpp-apiv3 links against the system cpprest package on
+# Debian/Ubuntu builds. Do not install packages implicitly in environments where
+# apt/dpkg is unavailable; instead print an actionable message.
+if command -v dpkg >/dev/null 2>&1 && ! dpkg -s libcpprest-dev >/dev/null 2>&1; then
+  if [ "$(id -u)" -eq 0 ] && command -v apt-get >/dev/null 2>&1; then
+    echo "libcpprest-dev not found, installing ..."
+    apt-get update
+    apt-get install -y libcpprest-dev
+  else
+    echo "libcpprest-dev is missing. Please install it first, for example:" >&2
+    echo "  sudo apt-get install libcpprest-dev" >&2
+    exit 1
+  fi
+fi
+
 cd ./third_party/cpprestsdk
 git apply ../custom_cache/cpprestsdk.patch


### PR DESCRIPTION
## Summary
  - Check whether `libcpprest-dev` is installed before applying the cpprestsdk patch.
  - Install it automatically only in Debian/Ubuntu root environments.
  - Print an actionable install hint in non-root or non-apt environments.

  ## Tests
  - `git diff --check origin/main..features/require-libcpprest-dev`