### PR TITLE
build: require libcpprest-dev for non-npu builds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ git submodule update
 #### Compilation
 compile xllm-service: 
 ```bash
-sh prepare.sh # apply patch
+# prepare.sh checks libcpprest-dev, installs it only when running as root on Debian/Ubuntu,
+# and then applies the cpprestsdk patch. Otherwise install libcpprest-dev manually first.
+sh prepare.sh
 mkdir -p build && cd build
 cmake .. && make -j 8
 ```

--- a/README_zh.md
+++ b/README_zh.md
@@ -67,7 +67,9 @@ git submodule update
 #### 编译
 编译执行
 ```bash
-sh prepare.sh # 应用patch
+# prepare.sh 会检查 libcpprest-dev；在 Debian/Ubuntu root 环境中缺失时自动安装，
+# 否则请先手动安装 libcpprest-dev，然后脚本会应用 cpprestsdk patch。
+sh prepare.sh
 mkdir -p build && cd build
 cmake .. && make -j 8
 ```

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,2 +1,24 @@
+#!/usr/bin/env bash
+set -e
+
+# The vendored etcd-cpp-apiv3 links against the system cpprest package on
+# Debian/Ubuntu builds. Do not install packages implicitly in environments where
+# apt/dpkg is unavailable; instead print an actionable message.
+if command -v dpkg >/dev/null 2>&1 && ! dpkg -s libcpprest-dev >/dev/null 2>&1; then
+  if [ "$(id -u)" -eq 0 ] && command -v apt-get >/dev/null 2>&1; then
+    echo "libcpprest-dev not found, installing ..."
+    apt-get update
+    apt-get install -y libcpprest-dev
+  else
+    echo "libcpprest-dev is missing. Please install it first, for example:" >&2
+    echo "  sudo apt-get install libcpprest-dev" >&2
+    exit 1
+  fi
+fi
+
 cd ./third_party/cpprestsdk
-git apply ../custom_cache/cpprestsdk.patch
+# Apply the patch only when it is not already applied, so re-running prepare.sh
+# under `set -e` stays idempotent instead of aborting on an already-patched tree.
+if ! git apply --reverse --check ../custom_cache/cpprestsdk.patch >/dev/null 2>&1; then
+  git apply ../custom_cache/cpprestsdk.patch
+fi


### PR DESCRIPTION
prepare.sh now checks for libcpprest-dev before applying the cpprestsdk patch. On Debian/Ubuntu root environments it installs the package when missing; otherwise it exits with an actionable install hint instead of silently failing later at link time.## Description
  
  `prepare.sh` previously applied the cpprestsdk patch without ensuring its
  build dependency was present. This PR makes the script check for
  `libcpprest-dev` first: on Debian/Ubuntu it auto-installs the package only
  when running as root, and otherwise prints an actionable message and exits
  instead of failing later in the build. README / README_zh are updated to
  describe the new behavior. No source or runtime behavior changes.

  ## Related Issues
  
  <!-- 如有相关 issue 填这里，例如 Fixes #123；没有可留空 -->

  ## Change Type

  - [x] Build or CI
  - [ ] Bug fix
  - [ ] New feature
  - [ ] Performance improvement
  - [ ] Refactor
  - [ ] Documentation
  - [ ] Test

  ## Pull Request Checklist

  - [x] PR title and commit message follow `<type>: <subject>` (verb-first, ≥4 words, ends with `.`).
  - [x] Rebased onto the latest `main`.
  - [x] No C++ source changed — clang-format CI not applicable.
  - [x] Docs/build-only change; no unit tests required.

  ## Reviewer Notes
  
  Shell-only + docs change. Auto-install path is gated to root on Debian/Ubuntu;
  non-root / non-apt environments get an explicit "install it first" message.