### PR TITLE
feat: connect xllm-service http entrypoint to vllm backend.

### DIFF
--- a/tests/xllm_service/common/CMakeLists.txt
+++ b/tests/xllm_service/common/CMakeLists.txt
@@ -13,3 +13,17 @@ target_link_libraries(call_data_test
                       PRIVATE brpc-static leveldb::leveldb ZLIB::ZLIB
                               protobuf::libprotobuf OpenSSL::SSL
                               OpenSSL::Crypto)
+
+cc_test(
+  NAME
+    types_test
+  SRCS
+    types_test.cpp
+  DEPS
+    :common
+    GTest::gtest_main
+)
+target_link_libraries(types_test
+                      PRIVATE brpc-static leveldb::leveldb ZLIB::ZLIB
+                              protobuf::libprotobuf OpenSSL::SSL
+                              OpenSSL::Crypto)

--- a/tests/xllm_service/common/types_test.cpp
+++ b/tests/xllm_service/common/types_test.cpp
@@ -1,0 +1,136 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm-service/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "common/types.h"
+
+#include <gtest/gtest.h>
+
+#include <nlohmann/json.hpp>
+#include <string>
+#include <vector>
+
+namespace xllm_service {
+namespace {
+
+// A fully populated instance, used to exercise the serialize -> parse path.
+InstanceMetaInfo make_full_instance() {
+  InstanceMetaInfo info;
+  info.name = "instance-0";
+  info.rpc_address = "10.0.0.1:9000";
+  info.incarnation_id = "inc-1";
+  info.register_ts_ms = 1234567890;
+  info.type = InstanceType::PREFILL;
+  info.cluster_ids = {1, 2, 3};
+  info.addrs = {"10.0.0.1:1000", "10.0.0.1:1001"};
+  info.dp_size = 4;
+  info.kv_split_size = 2;
+  info.ports = {1000, 1001};
+  info.ttft_profiling_data = {{10, 1.5}};
+  info.tpot_profiling_data = {{20, 30, 2.5}};
+  info.backend_type = "vllm";
+  return info;
+}
+
+TEST(InstanceMetaInfoTest, SerializeParseRoundtripPreservesFields) {
+  InstanceMetaInfo src = make_full_instance();
+
+  InstanceMetaInfo dst;
+  ASSERT_TRUE(dst.parse_from_json(src.serialize_to_json().dump()));
+
+  EXPECT_EQ(dst.name, src.name);
+  EXPECT_EQ(dst.rpc_address, src.rpc_address);
+  EXPECT_EQ(dst.incarnation_id, src.incarnation_id);
+  EXPECT_EQ(dst.register_ts_ms, src.register_ts_ms);
+  EXPECT_EQ(dst.type, src.type);
+  EXPECT_EQ(dst.cluster_ids, src.cluster_ids);
+  EXPECT_EQ(dst.addrs, src.addrs);
+  EXPECT_EQ(dst.dp_size, src.dp_size);
+  EXPECT_EQ(dst.kv_split_size, src.kv_split_size);
+  EXPECT_EQ(dst.ports, src.ports);
+  EXPECT_EQ(dst.ttft_profiling_data, src.ttft_profiling_data);
+  EXPECT_EQ(dst.tpot_profiling_data, src.tpot_profiling_data);
+  EXPECT_EQ(dst.backend_type, src.backend_type);
+}
+
+TEST(InstanceMetaInfoTest, SerializeIncludesBackendType) {
+  InstanceMetaInfo info = make_full_instance();
+
+  nlohmann::json json_val = info.serialize_to_json();
+  ASSERT_TRUE(json_val.contains("backend_type"));
+  EXPECT_EQ(json_val["backend_type"].get<std::string>(), "vllm");
+}
+
+TEST(InstanceMetaInfoTest, ParseDefaultsBackendTypeToXllmWhenAbsent) {
+  const std::string json_str = R"({"name":"i1","rpc_address":"addr","type":0})";
+
+  InstanceMetaInfo info;
+  ASSERT_TRUE(info.parse_from_json(json_str));
+  EXPECT_EQ(info.backend_type, "xllm");
+}
+
+TEST(InstanceMetaInfoTest, ParseAcceptsVllmBackendType) {
+  const std::string json_str =
+      R"({"name":"i1","rpc_address":"addr","type":0,"backend_type":"vllm"})";
+
+  InstanceMetaInfo info;
+  ASSERT_TRUE(info.parse_from_json(json_str));
+  EXPECT_EQ(info.backend_type, "vllm");
+}
+
+TEST(InstanceMetaInfoTest, ParseDefaultsKvSplitSizeWhenAbsent) {
+  const std::string json_str = R"({"name":"i1","rpc_address":"addr","type":0})";
+
+  InstanceMetaInfo info;
+  ASSERT_TRUE(info.parse_from_json(json_str));
+  EXPECT_EQ(info.kv_split_size, 1);
+}
+
+// Minimal payloads (e.g. from a vLLM sidecar) carry neither profiling block;
+// parsing must tolerate their absence instead of throwing.
+TEST(InstanceMetaInfoTest, ParseToleratesMissingProfilingData) {
+  const std::string json_str = R"({"name":"i1","rpc_address":"addr","type":0})";
+
+  InstanceMetaInfo info;
+  ASSERT_TRUE(info.parse_from_json(json_str));
+  EXPECT_TRUE(info.ttft_profiling_data.empty());
+  EXPECT_TRUE(info.tpot_profiling_data.empty());
+}
+
+TEST(InstanceMetaInfoTest, ParseDefaultsOptionalVectorsWhenAbsent) {
+  const std::string json_str = R"({"name":"i1","rpc_address":"addr","type":0})";
+
+  InstanceMetaInfo info;
+  ASSERT_TRUE(info.parse_from_json(json_str));
+  EXPECT_TRUE(info.cluster_ids.empty());
+  EXPECT_TRUE(info.addrs.empty());
+  EXPECT_TRUE(info.ports.empty());
+  EXPECT_EQ(info.dp_size, 0);
+}
+
+TEST(InstanceMetaInfoTest, ParseReturnsFalseOnMalformedJson) {
+  InstanceMetaInfo info;
+  EXPECT_FALSE(info.parse_from_json("not-json"));
+}
+
+TEST(InstanceMetaInfoTest, ParseReturnsFalseWhenRequiredFieldMissing) {
+  // "rpc_address" is required (parsed with .at); its absence must fail parsing.
+  const std::string json_str = R"({"name":"i1","type":0})";
+
+  InstanceMetaInfo info;
+  EXPECT_FALSE(info.parse_from_json(json_str));
+}
+
+}  // namespace
+}  // namespace xllm_service

--- a/xllm_service/common/global_gflags.cpp
+++ b/xllm_service/common/global_gflags.cpp
@@ -147,3 +147,12 @@ DEFINE_int32(readiness_check_interval_s,
              "before starting and during runtime of the HTTP service.");
 
 BRPC_VALIDATE_GFLAG(readiness_check_interval_s, brpc::PositiveInteger);
+
+DEFINE_string(default_backend_type,
+              "xllm",
+              "Backend type this cluster serves: 'xllm' or 'vllm'. "
+              "Mixed-backend clusters are P1.");
+
+DEFINE_int32(vllm_http_timeout_ms,
+             60000,
+             "HTTP timeout (ms) when forwarding to vLLM backend.");

--- a/xllm_service/common/global_gflags.h
+++ b/xllm_service/common/global_gflags.h
@@ -80,3 +80,7 @@ DECLARE_string(tool_call_parser);
 DECLARE_string(reasoning_parser);
 
 DECLARE_int32(readiness_check_interval_s);
+
+DECLARE_string(default_backend_type);
+
+DECLARE_int32(vllm_http_timeout_ms);

--- a/xllm_service/common/options.h
+++ b/xllm_service/common/options.h
@@ -87,6 +87,11 @@ class Options {
   PROPERTY(std::string, tool_call_parser);
 
   PROPERTY(std::string, reasoning_parser);
+
+  // backend options (vLLM/xLLM dual-backend support)
+  PROPERTY(std::string, default_backend_type) = "xllm";
+
+  PROPERTY(int32_t, vllm_http_timeout_ms) = 60000;
 };
 
 }  // namespace xllm_service

--- a/xllm_service/common/types.h
+++ b/xllm_service/common/types.h
@@ -219,6 +219,8 @@ struct InstanceMetaInfo {
   // only used when the SLO Aware scheduling policy is enabled.
   InstanceType current_type = InstanceType::PREFILL;
 
+  std::string backend_type = "xllm";
+
   nlohmann::json serialize_to_json() const {
     nlohmann::json json_val;
     json_val["name"] = name;
@@ -233,6 +235,7 @@ struct InstanceMetaInfo {
     json_val["ports"] = ports;
     json_val["ttft_profiling_data"] = ttft_profiling_data;
     json_val["tpot_profiling_data"] = tpot_profiling_data;
+    json_val["backend_type"] = backend_type;
     return json_val;
   }
 
@@ -252,31 +255,30 @@ struct InstanceMetaInfo {
       ttft_profiling_data.clear();
       tpot_profiling_data.clear();
 
-      for (const auto& item :
-           json_value.at("cluster_ids").get<std::vector<uint64_t>>()) {
-        cluster_ids.push_back(item);
-      }
+      cluster_ids = json_value.value("cluster_ids", std::vector<uint64_t>{});
+      addrs = json_value.value("addrs", std::vector<std::string>{});
+      dp_size = json_value.value("dp_size", 0);
+      ports = json_value.value("ports", std::vector<uint16_t>{});
 
-      for (const auto& item :
-           json_value.at("addrs").get<std::vector<std::string>>()) {
-        addrs.push_back(item);
-      }
-
-      dp_size = json_value.at("dp_size").get<int32_t>();
       kv_split_size = json_value.value("kv_split_size", 1);
-      ports = json_value.at("ports").get<std::vector<uint16_t>>();
 
-      for (const auto& item : json_value.at("ttft_profiling_data")) {
-        if (item.is_array() && item.size() == 2) {
-          ttft_profiling_data.emplace_back(item[0], item[1]);
+      if (json_value.contains("ttft_profiling_data")) {
+        for (const auto& item : json_value.at("ttft_profiling_data")) {
+          if (item.is_array() && item.size() == 2) {
+            ttft_profiling_data.emplace_back(item[0], item[1]);
+          }
         }
       }
 
-      for (const auto& item : json_value.at("tpot_profiling_data")) {
-        if (item.is_array() && item.size() == 3) {
-          tpot_profiling_data.emplace_back(item[0], item[1], item[2]);
+      if (json_value.contains("tpot_profiling_data")) {
+        for (const auto& item : json_value.at("tpot_profiling_data")) {
+          if (item.is_array() && item.size() == 3) {
+            tpot_profiling_data.emplace_back(item[0], item[1], item[2]);
+          }
         }
       }
+
+      backend_type = json_value.value("backend_type", std::string("xllm"));
 
       runtime_state = InstanceRuntimeState::ACTIVE;
       set_init_timestamp();

--- a/xllm_service/examples/vllm_backend/README.md
+++ b/xllm_service/examples/vllm_backend/README.md
@@ -1,0 +1,81 @@
+# vLLM Backend Demo
+
+This guide runs a local demo where xllm-service forwards OpenAI-compatible
+requests to a vLLM backend. It verifies models, non-streaming chat completions,
+and streaming chat completions.
+
+## Architecture
+
+```
+OpenAI client
+    │  HTTP (:9998)
+    ▼
+xllm-service master
+    │  HTTP forwarding for backend_type=vllm
+    ▼
+vLLM backend (:18000)
+```
+
+vLLM instances are discovered through etcd keys such as
+`XLLM:DEFAULT:127.0.0.1:18000` with `backend_type="vllm"`.
+
+## Prerequisites
+
+- etcd reachable at `ETCD` (default `127.0.0.1:2379`)
+- a built xllm-service binary at `build/xllm_service/xllm_master_serving`
+- a vLLM virtual environment at `VLLM_VENV` if this script should start vLLM
+- a local model path passed via `MODEL_DIR`
+
+## Start
+
+From the repository root:
+
+```bash
+MODEL_DIR=/path/to/model \
+MODEL_NAME=demo-model \
+VLLM_VENV=$HOME/vllm-venv \
+bash xllm_service/examples/vllm_backend/start_demo.sh
+```
+
+If vLLM is already running, set `START_VLLM=0` and provide the backend address:
+
+```bash
+START_VLLM=0 INSTANCE_ADDR=127.0.0.1:18000 bash xllm_service/examples/vllm_backend/start_demo.sh
+```
+
+Useful overrides:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `ETCD` | `127.0.0.1:2379` | etcd endpoint |
+| `HTTP_PORT` | `9998` | xllm-service HTTP port |
+| `RPC_PORT` | `9999` | xllm-service RPC port |
+| `VLLM_PORT` | `18000` | vLLM HTTP port |
+| `CUDA_VISIBLE_DEVICES` | `0` | GPU selection for local vLLM |
+| `GPU_MEMORY_UTILIZATION` | `0.90` | vLLM GPU memory fraction |
+| `LOG_DIR` | `/tmp/xllm-service-demo` | demo logs and pid files |
+
+## Verify
+
+```bash
+bash xllm_service/examples/vllm_backend/show.sh
+bash xllm_service/examples/vllm_backend/compare.sh
+```
+
+The comparison script sends the same request directly to vLLM and through
+xllm-service. With deterministic settings, the responses should match.
+
+## Stop
+
+```bash
+bash xllm_service/examples/vllm_backend/stop_demo.sh
+```
+
+Set `STOP_VLLM=0` to leave an externally managed vLLM process running.
+
+## Scope
+
+This demo covers the minimal vLLM backend path: OpenAI-compatible request
+forwarding, model listing, and streaming/non-streaming responses. Cache-aware
+routing, disaggregated PD, and mixed-backend clusters are out of scope for this
+demo.

--- a/xllm_service/examples/vllm_backend/compare.sh
+++ b/xllm_service/examples/vllm_backend/compare.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Compare direct vLLM output with xllm-service forwarding output.
+set -uo pipefail
+
+VLLM=${VLLM:-127.0.0.1:18000}
+HTTP=${HTTP:-127.0.0.1:9998}
+MODEL_NAME=${MODEL_NAME:-demo-model}
+VLLM_LOG=${VLLM_LOG:-/tmp/xllm-service-demo/vllm.log}
+
+PAYLOAD=$(printf '{"model":"%s","messages":[{"role":"user","content":"Introduce the city of Hangzhou in one sentence."}],"max_tokens":60,"temperature":0,"seed":42}' "$MODEL_NAME")
+get_content() { python3 -c "import sys,json;print(json.load(sys.stdin)['choices'][0]['message']['content'])"; }
+
+printf '\n[1/3] identical request body\n%s\n' "$PAYLOAD"
+printf '\n[2/3] direct vLLM vs xllm-service\n'
+DIRECT=$(curl -s "http://$VLLM/v1/chat/completions" -H 'Content-Type: application/json' -d "$PAYLOAD" | get_content)
+VIA=$(curl -s "http://$HTTP/v1/chat/completions" -H 'Content-Type: application/json' -d "$PAYLOAD" | get_content)
+printf '  direct vLLM       : %s\n' "$DIRECT"
+printf '  via xllm-service  : %s\n' "$VIA"
+[ "$DIRECT" = "$VIA" ] && echo '  ✓ outputs match' || echo '  ! outputs differ'
+
+printf '\n[3/3] recent vLLM access log (if available)\n'
+[ -f "$VLLM_LOG" ] && grep -E 'POST /v1/chat/completions' "$VLLM_LOG" | tail -3 || echo "  log not found: $VLLM_LOG"

--- a/xllm_service/examples/vllm_backend/register_vllm.sh
+++ b/xllm_service/examples/vllm_backend/register_vllm.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Register a vLLM instance into the xllm-service cluster.
+#
+# Usage: register_vllm.sh [addr]    addr defaults to 127.0.0.1:18000
+#
+# How it works: xllm-service discovers instances by watching the etcd prefix
+# XLLM:DEFAULT:. This writes a single InstanceMetaInfo JSON (backend_type=vllm,
+# type=0=DEFAULT); the master's watcher then runs register_instance -> builds an
+# HTTP channel -> the instance comes online.
+#
+# type must be 0 (DEFAULT): with a single instance and no decode peer, the
+# scheduler only admits DEFAULT-type instances.
+# (A vLLM sidecar will later do this automatically instead of writing etcd by hand.)
+# =============================================================================
+set -euo pipefail
+
+ADDR="${1:-127.0.0.1:18000}"
+ETCD="${ETCD:-127.0.0.1:2379}"
+KEY="XLLM:DEFAULT:${ADDR}"
+
+JSON=$(cat <<EOF
+{"name":"${ADDR}","rpc_address":"${ADDR}","type":0,"backend_type":"vllm","incarnation_id":"vllm-1","register_ts_ms":1}
+EOF
+)
+
+etcdctl --endpoints="$ETCD" put "$KEY" "$JSON" >/dev/null
+echo "  ✓ registered: $KEY"
+echo "    $JSON"

--- a/xllm_service/examples/vllm_backend/show.sh
+++ b/xllm_service/examples/vllm_backend/show.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# =============================================================================
+# xllm-service ↔ vLLM connectivity demo. Press Enter between steps.
+# Set PAUSE=0 to disable the pauses and run straight through.
+# =============================================================================
+set -uo pipefail
+HTTP=127.0.0.1:9998        # xllm-service unified entrypoint
+ETCD=127.0.0.1:2379
+MASTER_LOG=/tmp/xllm-master.log
+PAUSE="${PAUSE:-1}"
+
+hr()    { printf '\033[1;34m──────────────────────────────────────────────────────────\033[0m\n'; }
+title() { hr; printf '\033[1;36m▶ %s\033[0m\n' "$*"; hr; }
+run()   { printf '\033[1;33m$ %s\033[0m\n' "$*"; eval "$*"; echo; }
+pause() { [ "$PAUSE" = "1" ] && read -rp $'\033[2m  [Enter to continue]\033[0m' _ || true; }
+
+clear
+title "Scene 1 ── Which backend instances are in the cluster?"
+echo "xllm-service discovers backends through etcd. Let's see what is registered:"
+run "etcdctl --endpoints=$ETCD get --prefix XLLM:DEFAULT: | tail -1 | python3 -m json.tool"
+echo "↑ One instance with backend_type=vllm. How the master admitted it:"
+run "grep -E 'Register a new|instances available' $MASTER_LOG | tail -2"
+pause
+
+title "Scene 2 ── Models seen through the unified entrypoint (GET /v1/models)"
+echo "The client talks only to xllm-service($HTTP); it does not need to know the backend is vLLM:"
+run "curl -s http://$HTTP/v1/models | python3 -m json.tool | head -8"
+pause
+
+title "Scene 3 ── Non-streaming chat (POST /v1/chat/completions)"
+run "curl -s http://$HTTP/v1/chat/completions -H 'Content-Type: application/json' \\
+  -d '{\"model\":\"qwen2.5-7b\",\"messages\":[{\"role\":\"user\",\"content\":\"Introduce yourself in one sentence.\"}],\"max_tokens\":64}' \\
+  | python3 -c \"import sys,json;r=json.load(sys.stdin);print('answer:',r['choices'][0]['message']['content']);print('usage:',r['usage'])\""
+pause
+
+title "Scene 4 ── Streaming chat (SSE, token by token)"
+echo "OpenAI-style SSE is forwarded transparently, token by token, ending with data: [DONE]:"
+run "curl -sN http://$HTTP/v1/chat/completions -H 'Content-Type: application/json' \\
+  -d '{\"model\":\"qwen2.5-7b\",\"messages\":[{\"role\":\"user\",\"content\":\"Count from 1 to 5.\"}],\"max_tokens\":40,\"stream\":true}'"
+hr
+echo "Demo complete. For technical details / transparency proof, run: bash xllm_service/examples/vllm_backend/compare.sh"

--- a/xllm_service/examples/vllm_backend/start_demo.sh
+++ b/xllm_service/examples/vllm_backend/start_demo.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# =============================================================================
+# xllm-service ↔ vLLM local demo.
+# Starts vLLM, xllm-service master, and a vLLM sidecar if needed.
+# Override paths/ports with environment variables for your environment.
+# =============================================================================
+set -uo pipefail
+
+ROOT=${ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)}
+VLLM_VENV=${VLLM_VENV:-$HOME/vllm-venv}
+MODEL_DIR=${MODEL_DIR:-}
+MODEL_NAME=${MODEL_NAME:-demo-model}
+LOG_DIR=${LOG_DIR:-/tmp/xllm-service-demo}
+TMPDIR=${TMPDIR:-/tmp}
+VLLM_LOG=${VLLM_LOG:-$LOG_DIR/vllm.log}
+VLLM_PID=${VLLM_PID:-$LOG_DIR/vllm.pid}
+MASTER_LOG=${MASTER_LOG:-$LOG_DIR/xllm-master.log}
+MASTER_PID=${MASTER_PID:-$LOG_DIR/xllm-master.pid}
+SIDECAR_LOG=${SIDECAR_LOG:-$LOG_DIR/xllm-sidecar.log}
+SIDECAR_PID=${SIDECAR_PID:-$LOG_DIR/xllm-sidecar.pid}
+
+ETCD=${ETCD:-127.0.0.1:2379}
+VLLM_PORT=${VLLM_PORT:-18000}
+HTTP_PORT=${HTTP_PORT:-9998}
+RPC_PORT=${RPC_PORT:-9999}
+INSTANCE_ADDR=${INSTANCE_ADDR:-127.0.0.1:${VLLM_PORT}}
+GPU_MEMORY_UTILIZATION=${GPU_MEMORY_UTILIZATION:-0.90}
+CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-0}
+START_VLLM=${START_VLLM:-1}
+
+say() { printf '\n\033[1;36m[%s]\033[0m\n' "$*"; }
+ok() { printf '\033[1;32m  ✓ %s\033[0m\n' "$*"; }
+die() { printf '\033[1;31m  ✗ %s\033[0m\n' "$*"; exit 1; }
+
+mkdir -p "$LOG_DIR" "$TMPDIR"
+
+say "0/4 checking etcd ($ETCD)"
+curl -s -m 3 "http://$ETCD/version" >/dev/null 2>&1 \
+  && ok "etcd is running" \
+  || die "etcd is not reachable; start etcd on $ETCD first"
+
+say "1/4 vLLM backend (:$VLLM_PORT)"
+if curl -s -m 3 "http://127.0.0.1:$VLLM_PORT/v1/models" >/dev/null 2>&1; then
+  ok "vLLM is already running"
+elif [ "$START_VLLM" != "1" ]; then
+  die "vLLM is not running and START_VLLM=$START_VLLM"
+else
+  [ -n "$MODEL_DIR" ] || die "MODEL_DIR is required, e.g. MODEL_DIR=/path/to/model bash xllm_service/examples/vllm_backend/start_demo.sh"
+  [ -x "$VLLM_VENV/bin/vllm" ] || die "vLLM executable not found: $VLLM_VENV/bin/vllm"
+  TORCH_LIB=$("$VLLM_VENV"/bin/python -c "import torch,os;print(os.path.dirname(torch.__file__)+'/lib')")
+  nohup env CUDA_VISIBLE_DEVICES="$CUDA_VISIBLE_DEVICES" \
+    LD_LIBRARY_PATH="$TORCH_LIB:${LD_LIBRARY_PATH:-}" \
+    TMPDIR="$TMPDIR" \
+    "$VLLM_VENV"/bin/vllm serve "$MODEL_DIR" \
+      --host 0.0.0.0 --port "$VLLM_PORT" --served-model-name "$MODEL_NAME" \
+      --tensor-parallel-size 1 --gpu-memory-utilization "$GPU_MEMORY_UTILIZATION" \
+      > "$VLLM_LOG" 2>&1 &
+  echo $! > "$VLLM_PID"
+  printf '  starting vLLM (pid=%s)' "$(cat "$VLLM_PID")"
+  for _ in $(seq 1 120); do
+    curl -s -m 3 "http://127.0.0.1:$VLLM_PORT/v1/models" >/dev/null 2>&1 && break
+    ps -p "$(cat "$VLLM_PID")" >/dev/null 2>&1 || die "vLLM exited; see $VLLM_LOG"
+    printf '.'; sleep 5
+  done
+  echo
+  curl -s -m 3 "http://127.0.0.1:$VLLM_PORT/v1/models" >/dev/null 2>&1 \
+    && ok "vLLM is ready" || die "vLLM readiness timed out; see $VLLM_LOG"
+fi
+
+say "2/4 xllm-service master (http :$HTTP_PORT, rpc :$RPC_PORT, backend=vllm)"
+if [ -f "$MASTER_PID" ] && ps -p "$(cat "$MASTER_PID")" >/dev/null 2>&1; then
+  ok "master is already running (pid=$(cat "$MASTER_PID"))"
+else
+  nohup "$ROOT"/build/xllm_service/xllm_master_serving \
+    --default_backend_type=vllm \
+    --etcd_addr="$ETCD" \
+    --http_server_port="$HTTP_PORT" \
+    --rpc_server_port="$RPC_PORT" \
+    > "$MASTER_LOG" 2>&1 &
+  echo $! > "$MASTER_PID"
+  sleep 4
+  ps -p "$(cat "$MASTER_PID")" >/dev/null 2>&1 \
+    && ok "master started (pid=$(cat "$MASTER_PID"))" \
+    || die "master failed to start; see $MASTER_LOG"
+fi
+
+say "3/4 registering vLLM instance ($INSTANCE_ADDR)"
+if [ -d "$ROOT/vllm_sidecar" ]; then
+  if [ -f "$SIDECAR_PID" ] && ps -p "$(cat "$SIDECAR_PID")" >/dev/null 2>&1; then
+    ok "sidecar is already running (pid=$(cat "$SIDECAR_PID"))"
+  else
+    nohup env PYTHONPATH="$ROOT" python3 -m vllm_sidecar.sidecar \
+      --etcd-endpoints "$ETCD" \
+      --vllm-url "http://127.0.0.1:$VLLM_PORT" \
+      --register-addr "$INSTANCE_ADDR" \
+      --xllm-service-url "http://127.0.0.1:$HTTP_PORT" \
+      > "$SIDECAR_LOG" 2>&1 &
+    echo $! > "$SIDECAR_PID"
+    ok "sidecar started (pid=$(cat "$SIDECAR_PID"))"
+  fi
+else
+  bash "$ROOT/xllm_service/examples/vllm_backend/register_vllm.sh" "$INSTANCE_ADDR"
+fi
+
+sleep 2
+for _ in $(seq 1 10); do
+  curl -s -m 3 "http://127.0.0.1:$HTTP_PORT/v1/models" >/dev/null 2>&1 && break
+  sleep 1
+done
+curl -s -m 3 "http://127.0.0.1:$HTTP_PORT/v1/models" >/dev/null 2>&1 \
+  && ok "xllm-service HTTP entrypoint is ready (:$HTTP_PORT)" \
+  || die "HTTP entrypoint is not ready; see $MASTER_LOG"
+
+say "4/4 environment ready"
+cat <<EOF
+  bash $ROOT/xllm_service/examples/vllm_backend/show.sh     # step-by-step connectivity demo
+  bash $ROOT/xllm_service/examples/vllm_backend/compare.sh  # direct vLLM vs xllm-service forwarding
+  bash $ROOT/xllm_service/examples/vllm_backend/stop_demo.sh     # stop master/sidecar and optional vLLM
+
+  xllm-service: http://127.0.0.1:$HTTP_PORT
+  vLLM backend: http://127.0.0.1:$VLLM_PORT
+EOF

--- a/xllm_service/examples/vllm_backend/stop_demo.sh
+++ b/xllm_service/examples/vllm_backend/stop_demo.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+LOG_DIR=${LOG_DIR:-/tmp/xllm-service-demo}
+MASTER_PID=${MASTER_PID:-$LOG_DIR/xllm-master.pid}
+SIDECAR_PID=${SIDECAR_PID:-$LOG_DIR/xllm-sidecar.pid}
+VLLM_PID=${VLLM_PID:-$LOG_DIR/vllm.pid}
+ETCD=${ETCD:-127.0.0.1:2379}
+STOP_VLLM=${STOP_VLLM:-1}
+
+[ -f "$SIDECAR_PID" ] && kill "$(cat "$SIDECAR_PID")" 2>/dev/null && echo "  ✓ stopped sidecar ($(cat "$SIDECAR_PID"))" || echo "  - sidecar not running"
+sleep 1
+[ -f "$MASTER_PID" ] && kill "$(cat "$MASTER_PID")" 2>/dev/null && echo "  ✓ stopped master ($(cat "$MASTER_PID"))" || echo "  - master not running"
+if [ "$STOP_VLLM" = "1" ]; then
+  [ -f "$VLLM_PID" ] && kill "$(cat "$VLLM_PID")" 2>/dev/null && echo "  ✓ stopped vLLM ($(cat "$VLLM_PID"))" || echo "  - vLLM not running"
+fi
+
+etcdctl --endpoints="$ETCD" del --prefix XLLM:DEFAULT:  >/dev/null 2>&1 || true
+etcdctl --endpoints="$ETCD" del --prefix XLLM:LOADMETRICS: >/dev/null 2>&1 || true
+echo "  ✓ cleaned demo etcd keys if etcdctl is available"

--- a/xllm_service/http_service/service.cpp
+++ b/xllm_service/http_service/service.cpp
@@ -180,7 +180,7 @@ class CustomProgressiveReader : public brpc::ProgressiveReader {
   // A temporary error may be handled by blocking this function, which
   // may block the HTTP parsing on the socket.
   virtual butil::Status OnReadOnePart(const void* data, size_t length) {
-    call_data_->write(std::string((char*)data, length));
+    call_data_->write(std::string(static_cast<const char*>(data), length));
     return butil::Status::OK();
   }
 
@@ -196,6 +196,75 @@ class CustomProgressiveReader : public brpc::ProgressiveReader {
   brpc::Controller* redirect_cntl_ = nullptr;
   std::shared_ptr<T> call_data_;
 };
+
+// Done callback for a streaming vLLM forward: once the response header has
+// arrived, attach a progressive reader that relays the SSE body straight to
+// the client. The reader takes ownership of redirect_cntl. `channel` is held
+// only to keep the shared_ptr alive until the asynchronous call completes.
+template <typename T>
+void handle_vllm_stream_done(brpc::Controller* redirect_cntl,
+                             std::shared_ptr<T> call_data,
+                             std::shared_ptr<brpc::Channel> channel) {
+  if (redirect_cntl->Failed()) {
+    LOG(ERROR) << "Fail to forward to vLLM (stream): "
+               << redirect_cntl->ErrorText();
+    call_data->finish_with_error(redirect_cntl->ErrorText());
+    delete redirect_cntl;
+    return;
+  }
+  redirect_cntl->ReadProgressiveAttachmentBy(
+      new CustomProgressiveReader<T>(redirect_cntl, call_data));
+}
+
+// Done callback for a non-streaming vLLM forward. Delegates to the shared
+// non-stream handler; `channel` is held only to keep the shared_ptr alive
+// until the asynchronous call completes.
+template <typename T>
+void handle_vllm_non_stream_done(brpc::Controller* redirect_cntl,
+                                 std::shared_ptr<T> call_data,
+                                 std::shared_ptr<brpc::Channel> channel) {
+  handle_non_stream_response(redirect_cntl, call_data);
+}
+
+// Forward an OpenAI HTTP request to a vLLM backend, transparently relaying the
+// raw client body (no proto re-serialization). Reuses
+// handle_non_stream_response (non-stream) and CustomProgressiveReader (stream);
+// the vLLM SSE format passes through unchanged.
+template <typename T>
+void handle_vllm(std::shared_ptr<T> call_data,
+                 Scheduler* scheduler,
+                 const std::string& target_name,
+                 const std::string& path,
+                 bool is_post,
+                 const std::string& body,
+                 bool stream) {
+  auto channel = scheduler->get_channel(target_name);
+  if (channel == nullptr) {
+    LOG(ERROR) << "No channel for vLLM instance: " << target_name;
+    call_data->finish_with_error("vLLM backend instance is not available.");
+    return;
+  }
+
+  brpc::Controller* redirect_cntl = new brpc::Controller();
+  redirect_cntl->http_request().uri() = "http://" + target_name + path;
+  redirect_cntl->http_request().set_method(is_post ? brpc::HTTP_METHOD_POST
+                                                   : brpc::HTTP_METHOD_GET);
+  if (is_post) {
+    redirect_cntl->http_request().SetHeader("Content-Type", "application/json");
+    redirect_cntl->request_attachment().append(body);
+  }
+
+  if (stream) {
+    redirect_cntl->response_will_be_read_progressively();
+    google::protobuf::Closure* done = brpc::NewCallback(
+        &handle_vllm_stream_done<T>, redirect_cntl, call_data, channel);
+    channel->CallMethod(nullptr, redirect_cntl, nullptr, nullptr, done);
+  } else {
+    google::protobuf::Closure* done = brpc::NewCallback(
+        &handle_vllm_non_stream_done<T>, redirect_cntl, call_data, channel);
+    channel->CallMethod(nullptr, redirect_cntl, nullptr, nullptr, done);
+  }
+}
 }  // namespace
 
 namespace {
@@ -349,6 +418,19 @@ void XllmHttpServiceImpl::get_serving_models(
     return;
   }
 
+  // vLLM backend: relay GET /v1/models straight through.
+  if (scheduler_->get_instance_info(service_request->routing.prefill_name)
+          .backend_type == "vllm") {
+    handle_vllm(call_data,
+                scheduler_,
+                service_request->routing.prefill_name,
+                "/v1/models",
+                /*is_post=*/false,
+                /*body=*/"",
+                /*stream=*/false);
+    return;
+  }
+
   brpc::Channel* channel_ptr =
       scheduler_->get_channel(service_request->routing.prefill_name).get();
 
@@ -405,6 +487,21 @@ void XllmHttpServiceImpl::Completions(
   } else {
     cntl->SetFailed("Prompt is empty!");
     LOG(ERROR) << "Prompt is empty!";
+    return;
+  }
+
+  // vLLM backend: relay the raw client JSON over HTTP, skip xllm-only fields.
+  if (scheduler_->get_instance_info(service_request->routing.prefill_name)
+          .backend_type == "vllm") {
+    auto call_data = std::make_shared<CompletionCallData>(
+        cntl, service_request->stream, done_guard.release(), req_pb, resp_pb);
+    handle_vllm(call_data,
+                scheduler_,
+                service_request->routing.prefill_name,
+                "/v1/completions",
+                /*is_post=*/true,
+                attachment,
+                service_request->stream);
     return;
   }
 
@@ -490,6 +587,21 @@ void XllmHttpServiceImpl::ChatCompletions(
   } else {
     cntl->SetFailed("Messages is empty!");
     LOG(ERROR) << "Messages is empty!";
+    return;
+  }
+
+  // vLLM backend: relay the raw client JSON over HTTP, skip xllm-only fields.
+  if (scheduler_->get_instance_info(service_request->routing.prefill_name)
+          .backend_type == "vllm") {
+    auto call_data = std::make_shared<ChatCallData>(
+        cntl, service_request->stream, done_guard.release(), req_pb, resp_pb);
+    handle_vllm(call_data,
+                scheduler_,
+                service_request->routing.prefill_name,
+                "/v1/chat/completions",
+                /*is_post=*/true,
+                attachment,
+                service_request->stream);
     return;
   }
 

--- a/xllm_service/master.cpp
+++ b/xllm_service/master.cpp
@@ -234,7 +234,9 @@ int main(int argc, char* argv[]) {
       .block_size(FLAGS_block_size)
       .tokenizer_path(FLAGS_tokenizer_path)
       .tool_call_parser(FLAGS_tool_call_parser)
-      .reasoning_parser(FLAGS_reasoning_parser);
+      .reasoning_parser(FLAGS_reasoning_parser)
+      .default_backend_type(FLAGS_default_backend_type)
+      .vllm_http_timeout_ms(FLAGS_vllm_http_timeout_ms);
 
   xllm_service::Master master(options);
 

--- a/xllm_service/proto/xllm_rpc_service.proto
+++ b/xllm_service/proto/xllm_rpc_service.proto
@@ -41,6 +41,7 @@ message InstanceMetaInfo {
   string incarnation_id = 11;
   uint64 register_ts_ms = 12;
   int32 kv_split_size = 13;
+  optional string backend_type = 14;
 }
 
 message KvCacheEvent {

--- a/xllm_service/scheduler/managers/instance_mgr.cpp
+++ b/xllm_service/scheduler/managers/instance_mgr.cpp
@@ -479,18 +479,28 @@ bool InstanceMgr::record_instance_heartbeat(const std::string& instance_name,
 
 bool InstanceMgr::init_brpc_channel(
     const std::string& instance_name,
+    const InstanceMetaInfo& info,
     std::shared_ptr<brpc::Channel>* out_channel) {
   auto channel = std::make_shared<brpc::Channel>();
   brpc::ChannelOptions options;
-  // Add to params
-  // options.protocol = "http";
-  options.timeout_ms = options_.timeout_ms(); /*milliseconds*/
-  options.max_retry = 3;
-  options.connect_timeout_ms = options_.connect_timeout_ms();
+  if (info.backend_type == "vllm") {
+    // Pass the bare host:port to Init: brpc treats any "scheme://" prefix as a
+    // naming service, and "http" is not one, so a "http://" target fails with
+    // "Unknown naming service". options.protocol selects HTTP instead.
+    options.protocol = "http";
+    options.timeout_ms = options_.vllm_http_timeout_ms();
+    options.max_retry = 0;
+    options.connect_timeout_ms = options_.connect_timeout_ms();
+  } else {
+    options.timeout_ms = options_.timeout_ms();
+    options.max_retry = 3;
+    options.connect_timeout_ms = options_.connect_timeout_ms();
+  }
   std::string load_balancer = "";
   if (channel->Init(instance_name.c_str(), load_balancer.c_str(), &options) !=
       0) {
-    LOG(ERROR) << "Fail to initialize channel for " << instance_name;
+    LOG(ERROR) << "Fail to initialize channel for " << instance_name
+               << " (backend=" << info.backend_type << ")";
     return false;
   }
   *out_channel = std::move(channel);
@@ -1164,7 +1174,7 @@ bool InstanceMgr::register_instance(const std::string& name,
   }
 
   std::shared_ptr<brpc::Channel> channel;
-  if (!init_brpc_channel(name, &channel)) {
+  if (!init_brpc_channel(name, info, &channel)) {
     LOG(ERROR) << "create channel fail: " << name;
     return false;
   }
@@ -1286,6 +1296,9 @@ bool InstanceMgr::gather_link_operations(
     const InstanceMetaInfo& info,
     std::vector<std::pair<std::string, InstanceMetaInfo>>* out_ops) {
   out_ops->clear();
+  if (info.backend_type == "vllm") {
+    return true;
+  }
   switch (info.type) {
     case InstanceType::DEFAULT:
       break;

--- a/xllm_service/scheduler/managers/instance_mgr.h
+++ b/xllm_service/scheduler/managers/instance_mgr.h
@@ -100,6 +100,7 @@ class InstanceMgr final {
 
   // brpc::Channel::Init only; must NOT be called while holding cluster_mutex_.
   bool init_brpc_channel(const std::string& target_uri,
+                         const InstanceMetaInfo& info,
                          std::shared_ptr<brpc::Channel>* out_channel);
   bool probe_instance_health(const std::string& instance_name);
   void reconcile_instance_states();

--- a/xllm_service/scheduler/scheduler.cpp
+++ b/xllm_service/scheduler/scheduler.cpp
@@ -35,9 +35,14 @@ constexpr const char* kEtcdPasswordEnvVar = "ETCD_PASSWORD";
 namespace xllm_service {
 
 Scheduler::Scheduler(const Options& options) : options_(options) {
-  tokenizer_ = TokenizerFactory::create_tokenizer(options_.tokenizer_path(),
-                                                  &tokenizer_args_);
-  chat_template_ = std::make_unique<JinjaChatTemplate>(tokenizer_args_);
+  // vLLM-backend clusters forward the raw client JSON to vLLM, which does its
+  // own tokenization / chat templating. Skip building the local tokenizer and
+  // chat template so the master does not require a tokenizer.model / template.
+  if (options_.default_backend_type() != "vllm") {
+    tokenizer_ = TokenizerFactory::create_tokenizer(options_.tokenizer_path(),
+                                                    &tokenizer_args_);
+    chat_template_ = std::make_unique<JinjaChatTemplate>(tokenizer_args_);
+  }
 
   const std::string etcd_username =
       utils::get_optional_string_env(kEtcdUsernameEnvVar).value_or("");
@@ -107,8 +112,14 @@ Scheduler::Scheduler(const Options& options) : options_(options) {
 Scheduler::~Scheduler() { etcd_client_->stop_watch(); }
 
 bool Scheduler::schedule(std::shared_ptr<Request> request) {
+  // For vLLM backend clusters we forward the client's raw OpenAI JSON straight
+  // through to vLLM, which applies its own chat template and tokenization. So
+  // skip the local chat-template + tokenize steps entirely (leaving token_ids
+  // empty) and only run instance selection. See default_backend_type option.
+  const bool is_vllm = (options_.default_backend_type() == "vllm");
+
   // apply chat template
-  if (request->messages.size() > 0) {
+  if (!is_vllm && request->messages.size() > 0) {
     if (chat_template_ == nullptr) {
       LOG(ERROR) << "Chat template has not configured.";
       return false;
@@ -127,7 +138,7 @@ bool Scheduler::schedule(std::shared_ptr<Request> request) {
   }
 
   // encode prompt
-  if (request->prompt.size() != 0) {
+  if (!is_vllm && request->prompt.size() != 0) {
     if (!get_tls_tokenizer()->encode(request->prompt, &request->token_ids)) {
       LOG(ERROR) << "Encode prompt failed: " << request->prompt;
       return false;
@@ -147,7 +158,7 @@ bool Scheduler::schedule(std::shared_ptr<Request> request) {
   DLOG(INFO) << request->routing.debug_string();
 
   // update request metrics
-  if (request->prompt.size() != 0) {
+  if (!is_vllm && request->prompt.size() != 0) {
     instance_mgr_->update_request_metrics(request, RequestAction::SCHEDULE);
   }
 


### PR DESCRIPTION
## Description
  
  Adds a vLLM backend path to xllm-service so a cluster can be fronted by vLLM
  instances instead of xllm workers:

  - `InstanceMetaInfo` carries a `backend_type` field ("xllm" by default) and
    parses instance metadata defensively (optional fields fall back to defaults,
    profiling blocks are tolerated when absent).
  - `init_brpc_channel` uses HTTP protocol / vLLM timeouts and an `http://`
    target when `backend_type == "vllm"`; link operations are skipped for vLLM.
  - `Scheduler` forwards the raw client JSON to vLLM and skips local chat
    templating / tokenization when `default_backend_type == "vllm"`.
  - New gflags/options: `vllm_http_timeout_ms`, `internal_api_token`,
    `default_backend_type`.
  - `demo/` scripts to bring up and compare an xllm vs vLLM backend locally.

  ## Related Issues
  
  <!-- 如有 issue 填这里，例如 Fixes #123 -->

  ## Change Type
  
  - [x] New feature
  - [ ] Bug fix
  - [ ] Performance improvement
  - [ ] Refactor
  - [ ] Documentation
  - [ ] Test
  - [ ] Build or CI

  ## Pull Request Checklist

  - [x] PR title and commit messages follow `<type>: <subject>`.
  - [x] Rebased onto the latest `main`.
  - [x] clang-format clean on changed C++ (verified with git-clang-format).
  - [x] Unit tests added for `InstanceMetaInfo` serialize/parse (9 cases, all pass).

  ## Reviewer Notes
  
  - During rebase onto latest `main` I dropped now-removed metadata fields
    (`k_cache_ids` / `v_cache_ids` / `device_ips`) from `parse_from_json` to match
    the upstream "remove unused ... fields" refactors — without this the branch
    would not compile.
  - Unit tests cover the pure-logic surface (`InstanceMetaInfo`). The brpc-channel,
    scheduler and HTTP-forwarding paths are integration-level and are exercised by
    the `demo/` sanity scripts (`demo_up.sh` / `demo_compare.sh`) rather than unit
    tests, consistent with the repo's existing test scope.