### PR TITLE
refactor: fix and refactor anthropic thinking parser and tool calls.

### DIFF
--- a/tests/xllm_service/CMakeLists.txt
+++ b/tests/xllm_service/CMakeLists.txt
@@ -1,2 +1,4 @@
+add_subdirectory(chat_template)
 add_subdirectory(common)
 add_subdirectory(http_service)
+add_subdirectory(scheduler)

--- a/tests/xllm_service/chat_template/CMakeLists.txt
+++ b/tests/xllm_service/chat_template/CMakeLists.txt
@@ -1,0 +1,11 @@
+include(cc_test)
+
+cc_test(
+  NAME
+    message_projection_test
+  SRCS
+    message_projection_test.cpp
+  DEPS
+    :message_projection
+    GTest::gtest_main
+)

--- a/tests/xllm_service/chat_template/message_projection_test.cpp
+++ b/tests/xllm_service/chat_template/message_projection_test.cpp
@@ -1,0 +1,119 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm-service/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "chat_template/message_projection.h"
+
+#include <gtest/gtest.h>
+
+namespace xllm_service {
+namespace {
+
+TEST(MessageProjectionTest, CopiesRoleAndStringContent) {
+  Message msg("user", "hello");
+
+  xllm::proto::ChatMessage proto;
+  to_proto(msg, &proto);
+
+  EXPECT_EQ(proto.role(), "user");
+  EXPECT_EQ(proto.content(), "hello");
+}
+
+TEST(MessageProjectionTest, FlattensContentVecToTextBlocksOnly) {
+  Message::MMContentVec blocks;
+  Message::MMContent thinking("thinking");
+  thinking.thinking = "hidden";
+  blocks.push_back(thinking);
+  Message::MMContent tool_use("tool_use");
+  tool_use.id = "toolu_1";
+  blocks.push_back(tool_use);
+  blocks.emplace_back("text", "first");
+  blocks.emplace_back("text", "second");
+
+  Message msg("assistant", blocks);
+
+  xllm::proto::ChatMessage proto;
+  to_proto(msg, &proto);
+
+  EXPECT_EQ(proto.role(), "assistant");
+  EXPECT_EQ(proto.content(), "first\nsecond");
+}
+
+TEST(MessageProjectionTest, ProjectsToolCallsAndReasoningContent) {
+  Message msg("assistant", "done");
+  msg.reasoning_content = "hidden reasoning";
+  Message::ToolCall call;
+  call.id = "toolu_1";
+  call.type = "function";
+  call.function.name = "get_weather";
+  call.function.arguments = R"({"city":"Beijing"})";
+  msg.tool_calls = Message::ToolCallVec{call};
+
+  xllm::proto::ChatMessage proto;
+  to_proto(msg, &proto);
+
+  ASSERT_TRUE(proto.has_reasoning_content());
+  EXPECT_EQ(proto.reasoning_content(), "hidden reasoning");
+  ASSERT_EQ(proto.tool_calls_size(), 1);
+  EXPECT_EQ(proto.tool_calls(0).id(), "toolu_1");
+  EXPECT_EQ(proto.tool_calls(0).type(), "function");
+  EXPECT_EQ(proto.tool_calls(0).function().name(), "get_weather");
+  EXPECT_EQ(proto.tool_calls(0).function().arguments(),
+            R"({"city":"Beijing"})");
+}
+
+TEST(MessageProjectionTest, OmitsEmptyReasoningContentAndToolCallId) {
+  Message msg("user", "hi");
+  msg.reasoning_content = "";
+
+  xllm::proto::ChatMessage proto;
+  to_proto(msg, &proto);
+
+  EXPECT_FALSE(proto.has_reasoning_content());
+  EXPECT_FALSE(proto.has_tool_call_id());
+  EXPECT_EQ(proto.tool_calls_size(), 0);
+}
+
+TEST(MessageProjectionTest, SetsToolCallIdForToolRole) {
+  Message msg("tool", "sunny");
+  msg.tool_call_id = "toolu_1";
+
+  xllm::proto::ChatMessage proto;
+  to_proto(msg, &proto);
+
+  EXPECT_EQ(proto.role(), "tool");
+  EXPECT_EQ(proto.content(), "sunny");
+  ASSERT_TRUE(proto.has_tool_call_id());
+  EXPECT_EQ(proto.tool_call_id(), "toolu_1");
+}
+
+TEST(MessageProjectionTest, NeedsContentVecRules) {
+  EXPECT_FALSE(needs_content_vec({}));
+
+  Message::MMContentVec single_text;
+  single_text.emplace_back("text", "only");
+  EXPECT_FALSE(needs_content_vec(single_text));
+
+  Message::MMContentVec single_thinking;
+  single_thinking.emplace_back("thinking");
+  EXPECT_TRUE(needs_content_vec(single_thinking));
+
+  Message::MMContentVec two_texts;
+  two_texts.emplace_back("text", "a");
+  two_texts.emplace_back("text", "b");
+  EXPECT_TRUE(needs_content_vec(two_texts));
+}
+
+}  // namespace
+}  // namespace xllm_service

--- a/tests/xllm_service/common/CMakeLists.txt
+++ b/tests/xllm_service/common/CMakeLists.txt
@@ -27,3 +27,17 @@ target_link_libraries(types_test
                       PRIVATE brpc-static leveldb::leveldb ZLIB::ZLIB
                               protobuf::libprotobuf OpenSSL::SSL
                               OpenSSL::Crypto)
+
+cc_test(
+  NAME
+    anthropic_tracer_test
+  SRCS
+    anthropic_tracer_test.cpp
+  DEPS
+    :common
+    GTest::gtest_main
+)
+target_link_libraries(anthropic_tracer_test
+                      PRIVATE brpc-static leveldb::leveldb ZLIB::ZLIB
+                              protobuf::libprotobuf OpenSSL::SSL
+                              OpenSSL::Crypto)

--- a/tests/xllm_service/common/anthropic_tracer_test.cpp
+++ b/tests/xllm_service/common/anthropic_tracer_test.cpp
@@ -1,0 +1,64 @@
+/* Copyright 2025 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm-service/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "common/anthropic_tracer.h"
+
+#include <gflags/gflags.h>
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "common/global_gflags.h"
+
+namespace xllm_service {
+
+TEST(AnthropicTracerTest, FormatsTraceWhenEnabled) {
+  FLAGS_enable_request_trace = true;
+  std::vector<std::string> received;
+  AnthropicTracer tracer(
+      [&](const std::string& formatted) { received.push_back(formatted); },
+      "req-1",
+      "svc-1");
+
+  tracer.trace("stream_sse", "hello");
+
+  ASSERT_EQ(received.size(), 1u);
+  EXPECT_EQ(received[0], "[anthropic][stream_sse] hello");
+}
+
+TEST(AnthropicTracerTest, DoesNotCallSinkWhenDisabled) {
+  FLAGS_enable_request_trace = false;
+  std::vector<std::string> received;
+  AnthropicTracer tracer(
+      [&](const std::string& formatted) { received.push_back(formatted); },
+      "req-1",
+      "svc-1");
+
+  tracer.trace("stream_sse", "hello");
+
+  EXPECT_TRUE(received.empty());
+}
+
+TEST(AnthropicTracerTest, NoCrashWhenSinkIsEmpty) {
+  FLAGS_enable_request_trace = true;
+  AnthropicTracer tracer(/*sink=*/nullptr, "req-1", "svc-1");
+
+  // Mirrors the service.cpp path where request == nullptr or the trace
+  // callback is unset: the call must be a safe no-op.
+  EXPECT_NO_FATAL_FAILURE(tracer.trace("raw_http_request", "payload"));
+}
+
+}  // namespace xllm_service

--- a/tests/xllm_service/http_service/CMakeLists.txt
+++ b/tests/xllm_service/http_service/CMakeLists.txt
@@ -19,3 +19,13 @@ cc_test(
     :anthropic_adapter
     GTest::gtest_main
 )
+
+cc_test(
+  NAME
+    anthropic_stream_encoder_test
+  SRCS
+    anthropic_stream_encoder_test.cpp
+  DEPS
+    :anthropic_stream_encoder
+    GTest::gtest_main
+)

--- a/tests/xllm_service/http_service/anthropic_adapter_test.cpp
+++ b/tests/xllm_service/http_service/anthropic_adapter_test.cpp
@@ -18,11 +18,15 @@ limitations under the License.
 #include <gtest/gtest.h>
 
 #include <nlohmann/json.hpp>
+#include <optional>
 #include <string>
 #include <variant>
 
 namespace xllm_service {
 namespace {
+
+constexpr const char* kOldThinkingSignature =
+    "xllm-anthropic-thinking-signature-v1";
 
 xllm::proto::AnthropicMessagesRequest parse_request(const std::string& json) {
   xllm::proto::AnthropicMessagesRequest request;
@@ -460,6 +464,336 @@ TEST(AnthropicAdapterTest, MapsToolUseAndToolResultHistory) {
   EXPECT_EQ(messages[1].tool_call_id, "toolu_1");
 }
 
+TEST(AnthropicAdapterTest, DropsEmptyBashToolUseAndMatchingResultHistory) {
+  auto request = parse_request(R"({
+    "model": "test-model",
+    "max_tokens": 8,
+    "messages": [
+      {
+        "role": "assistant",
+        "content": [
+          {"type": "text", "text": "Trying a command."},
+          {
+            "type": "tool_use",
+            "id": "toolu_bad",
+            "name": "Bash",
+            "input": {}
+          }
+        ]
+      },
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "tool_result",
+            "tool_use_id": "toolu_bad",
+            "content": "<tool_use_error>InputValidationError: Bash failed</tool_use_error>",
+            "is_error": true
+          },
+          {"type": "text", "text": "Continue from where you left off."}
+        ]
+      }
+    ]
+  })");
+
+  xllm::proto::ChatRequest chat_request;
+  ChatMessages messages;
+  auto result = adapt_request(request, &chat_request, &messages);
+  ASSERT_TRUE(result.ok) << result.error;
+
+  ASSERT_EQ(chat_request.messages_size(), 2);
+  const auto& assistant = chat_request.messages(0);
+  EXPECT_EQ(assistant.role(), "assistant");
+  EXPECT_EQ(assistant.content(), "Trying a command.");
+  EXPECT_EQ(assistant.tool_calls_size(), 0);
+
+  const auto& user = chat_request.messages(1);
+  EXPECT_EQ(user.role(), "user");
+  EXPECT_EQ(user.content(), "Continue from where you left off.");
+
+  ASSERT_EQ(messages.size(), 2);
+  EXPECT_EQ(messages[0].role, "assistant");
+  EXPECT_FALSE(messages[0].tool_calls.has_value());
+  EXPECT_EQ(messages[1].role, "user");
+  EXPECT_EQ(text_content(messages[1]), "Continue from where you left off.");
+}
+
+TEST(AnthropicAdapterTest, PreservesThinkingBlocksInHistory) {
+  auto request = parse_request(R"({
+    "model": "test-model",
+    "max_tokens": 8,
+    "messages": [
+      {
+        "role": "assistant",
+        "content": [
+          {
+            "type": "thinking",
+            "thinking": "hidden reasoning",
+            "signature": "sig_1"
+          },
+          {
+            "type": "tool_use",
+            "id": "toolu_1",
+            "name": "write_file",
+            "input": {"file_path": "two_sum.py", "content": "print_one"}
+          },
+          {"type": "redacted_thinking", "data": "opaque_base64"},
+          {"type": "text", "text": "done"}
+        ]
+      },
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "tool_result",
+            "tool_use_id": "toolu_1",
+            "content": "Error writing file"
+          }
+        ]
+      }
+    ]
+  })");
+
+  const auto& blocks = request.messages(0).content_blocks().blocks();
+  ASSERT_EQ(blocks.size(), 4);
+  EXPECT_EQ(blocks[0].type(), "thinking");
+  ASSERT_TRUE(blocks[0].has_thinking());
+  EXPECT_EQ(blocks[0].thinking(), "hidden reasoning");
+  ASSERT_TRUE(blocks[0].has_signature());
+  EXPECT_EQ(blocks[0].signature(), "sig_1");
+  EXPECT_EQ(blocks[1].type(), "tool_use");
+  EXPECT_EQ(blocks[2].type(), "redacted_thinking");
+  ASSERT_TRUE(blocks[2].has_data());
+  EXPECT_EQ(blocks[2].data(), "opaque_base64");
+  EXPECT_EQ(blocks[3].type(), "text");
+
+  xllm::proto::ChatRequest chat_request;
+  ChatMessages messages;
+  auto result = adapt_request(request, &chat_request, &messages);
+  ASSERT_TRUE(result.ok) << result.error;
+
+  ASSERT_EQ(chat_request.messages_size(), 2);
+  const auto& assistant = chat_request.messages(0);
+  EXPECT_EQ(assistant.role(), "assistant");
+  EXPECT_EQ(assistant.content(), "done");
+  ASSERT_TRUE(assistant.has_reasoning_content());
+  EXPECT_EQ(assistant.reasoning_content(), "hidden reasoning");
+  ASSERT_EQ(assistant.tool_calls_size(), 1);
+  EXPECT_EQ(assistant.tool_calls(0).id(), "toolu_1");
+  EXPECT_EQ(assistant.tool_calls(0).function().name(), "write_file");
+  auto args =
+      nlohmann::json::parse(assistant.tool_calls(0).function().arguments());
+  EXPECT_EQ(args["file_path"], "two_sum.py");
+  EXPECT_EQ(args["content"], "print_one");
+
+  const auto& tool_result = chat_request.messages(1);
+  EXPECT_EQ(tool_result.role(), "tool");
+  EXPECT_EQ(tool_result.tool_call_id(), "toolu_1");
+  EXPECT_EQ(tool_result.content(), "Error writing file");
+
+  ASSERT_EQ(messages.size(), 2);
+  EXPECT_EQ(messages[0].role, "assistant");
+  ASSERT_TRUE(messages[0].tool_calls.has_value());
+  ASSERT_TRUE(messages[0].reasoning_content.has_value());
+  EXPECT_EQ(messages[0].reasoning_content.value(), "hidden reasoning");
+  ASSERT_TRUE(
+      std::holds_alternative<Message::MMContentVec>(messages[0].content));
+  const auto& content = std::get<Message::MMContentVec>(messages[0].content);
+  ASSERT_EQ(content.size(), 4);
+  EXPECT_EQ(content[0].type, "thinking");
+  EXPECT_EQ(content[0].thinking, "hidden reasoning");
+  EXPECT_EQ(content[0].signature, "sig_1");
+  EXPECT_EQ(content[1].type, "tool_use");
+  EXPECT_EQ(content[1].id, "toolu_1");
+  EXPECT_EQ(content[1].name, "write_file");
+  EXPECT_EQ(content[1].input["file_path"], "two_sum.py");
+  EXPECT_EQ(content[1].input["content"], "print_one");
+  EXPECT_EQ(content[2].type, "redacted_thinking");
+  EXPECT_EQ(content[2].data, "opaque_base64");
+  EXPECT_EQ(content[3].type, "text");
+  EXPECT_EQ(content[3].text, "done");
+  EXPECT_EQ(messages[1].role, "tool");
+}
+
+TEST(AnthropicAdapterTest, RendersPreservedThinkingBlocksToTemplate) {
+  auto request = parse_request(R"({
+    "model": "test-model",
+    "max_tokens": 8,
+    "messages": [
+      {
+        "role": "assistant",
+        "content": [
+          {
+            "type": "thinking",
+            "thinking": "plan A",
+            "signature": "sig_a"
+          },
+          {
+            "type": "tool_use",
+            "id": "toolu_1",
+            "name": "Read",
+            "input": {"path": "a.txt"}
+          },
+          {"type": "redacted_thinking", "data": "opaque_a"},
+          {
+            "type": "thinking",
+            "thinking": "plan B",
+            "signature": "sig_b"
+          },
+          {"type": "text", "text": "done"}
+        ]
+      },
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "tool_result",
+            "tool_use_id": "toolu_1",
+            "content": "missing"
+          }
+        ]
+      }
+    ]
+  })");
+
+  xllm::proto::ChatRequest chat_request;
+  ChatMessages messages;
+  auto result = adapt_request(request, &chat_request, &messages);
+  ASSERT_TRUE(result.ok) << result.error;
+
+  ASSERT_EQ(messages.size(), 2);
+  ASSERT_TRUE(
+      std::holds_alternative<Message::MMContentVec>(messages[0].content));
+  const auto& content = std::get<Message::MMContentVec>(messages[0].content);
+  ASSERT_EQ(content.size(), 5);
+  EXPECT_EQ(content[0].type, "thinking");
+  EXPECT_EQ(content[0].thinking, "plan A");
+  EXPECT_EQ(content[0].signature, "sig_a");
+  EXPECT_EQ(content[1].type, "tool_use");
+  EXPECT_EQ(content[1].id, "toolu_1");
+  EXPECT_EQ(content[1].name, "Read");
+  EXPECT_EQ(content[1].input["path"], "a.txt");
+  EXPECT_EQ(content[2].type, "redacted_thinking");
+  EXPECT_EQ(content[2].data, "opaque_a");
+  EXPECT_EQ(content[3].type, "thinking");
+  EXPECT_EQ(content[3].thinking, "plan B");
+  EXPECT_EQ(content[3].signature, "sig_b");
+  EXPECT_EQ(content[4].type, "text");
+  EXPECT_EQ(content[4].text, "done");
+  ASSERT_TRUE(messages[0].reasoning_content.has_value());
+  EXPECT_EQ(messages[0].reasoning_content.value(), "plan Aplan B");
+  EXPECT_EQ(messages[1].role, "tool");
+  EXPECT_EQ(messages[1].tool_call_id, "toolu_1");
+  EXPECT_EQ(text_content(messages[1]), "missing");
+
+  const std::string template_str =
+      "{% if messages[0]['content'] is string %}{{ messages[0]['content'] }}"
+      "{% endif %}"
+      "{% if messages[0]['content'] is not string %}"
+      "{% for item in messages[0]['content'] %}"
+      "{{ item['type'] }}:"
+      "{% if item['type'] == 'thinking' %}{{ item['thinking'] }}:{{ "
+      "item['signature'] }}{% endif %}"
+      "{% if item['type'] == 'tool_use' %}{{ item['id'] }}:{{ item['name'] "
+      "}}:{{ item['input']['path'] }}{% endif %}"
+      "{% if item['type'] == 'redacted_thinking' %}{{ item['data'] }}{% endif "
+      "%}"
+      "{% if item['type'] == 'text' %}{{ item['text'] }}{% endif %}|"
+      "{% endfor %}"
+      "{% endif %}"
+      "{% for message in messages %}"
+      "{% if message.get('tool_calls') %}"
+      "{% for tool_call in message['tool_calls'] %}"
+      "call={{ tool_call['function']['name'] }}:"
+      "{{ tool_call['function']['arguments'] }}|"
+      "{% endfor %}"
+      "{% endif %}"
+      "{% if message['role'] == 'tool' %}"
+      "tool={{ message['role'] }}:{{ message['tool_call_id'] }}:"
+      "{{ message['content'] }}"
+      "{% endif %}"
+      "{% endfor %}";
+
+  TokenizerArgs args;
+  args.chat_template(template_str);
+  args.bos_token("");
+  args.eos_token("");
+  JinjaChatTemplate template_(args);
+
+  auto prompt = template_.apply(messages);
+  ASSERT_TRUE(prompt.has_value());
+  EXPECT_EQ(prompt.value(),
+            "thinking:plan A:sig_a|tool_use:toolu_1:Read:a.txt|"
+            "redacted_thinking:opaque_a|thinking:plan B:sig_b|text:done|"
+            "call=Read:{\"path\":\"a.txt\"}|"
+            "tool=tool:toolu_1:missing");
+}
+
+TEST(AnthropicAdapterTest, RendersPreservedThinkingForStringTemplate) {
+  auto request = parse_request(R"({
+    "model": "test-model",
+    "max_tokens": 8,
+    "messages": [
+      {
+        "role": "assistant",
+        "content": [
+          {
+            "type": "thinking",
+            "thinking": "PTB_marker",
+            "signature": "sig_a"
+          },
+          {
+            "type": "tool_use",
+            "id": "toolu_1",
+            "name": "Read",
+            "input": {"marker": "TIB_marker"}
+          },
+          {"type": "text", "text": "done"}
+        ]
+      },
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "tool_result",
+            "tool_use_id": "toolu_1",
+            "content": "TRB_marker"
+          }
+        ]
+      }
+    ]
+  })");
+
+  xllm::proto::ChatRequest chat_request;
+  ChatMessages messages;
+  auto result = adapt_request(request, &chat_request, &messages);
+  ASSERT_TRUE(result.ok) << result.error;
+
+  const std::string template_str =
+      "{% for message in messages %}"
+      "{{ message['role'] }}:"
+      "{% if message['content'] is string %}{{ message['content'] }}{% endif "
+      "%}|"
+      "{% if message.get('tool_calls') %}"
+      "{% for tool_call in message['tool_calls'] %}"
+      "call={{ tool_call['function']['arguments'] }}|"
+      "{% endfor %}"
+      "{% endif %}"
+      "{% endfor %}";
+
+  TokenizerArgs args;
+  args.chat_template(template_str);
+  args.bos_token("");
+  args.eos_token("");
+  JinjaChatTemplate template_(args);
+
+  auto prompt = template_.apply(messages);
+  ASSERT_TRUE(prompt.has_value());
+  EXPECT_NE(prompt->find("<think>PTB_marker</think>"), std::string::npos);
+  EXPECT_NE(prompt->find("TIB_marker"), std::string::npos);
+  EXPECT_NE(prompt->find("TRB_marker"), std::string::npos);
+}
+
 TEST(AnthropicAdapterTest, BuildsNonStreamAnthropicJson) {
   llm::RequestOutput output;
   output.request_id = "anthropiccmpl-test";
@@ -497,6 +831,50 @@ TEST(AnthropicAdapterTest, BuildsNonStreamAnthropicJson) {
   EXPECT_FALSE(json["usage"].contains("total_tokens"));
 }
 
+TEST(AnthropicAdapterTest, BuildsThinkingNonStreamAnthropicJson) {
+  llm::RequestOutput output;
+  output.request_id = "anthropiccmpl-test";
+  output.finished = true;
+  llm::SequenceOutput seq;
+  seq.index = 0;
+  seq.text = "answer";
+  seq.finish_reason = "stop";
+  output.outputs.push_back(std::move(seq));
+
+  xllm::proto::AnthropicMessagesResponse response;
+  auto result = fill_anthropic_resp("test-model", output, &response);
+  ASSERT_TRUE(result.ok) << result.error;
+
+  std::string json_str;
+  std::string error;
+  ASSERT_TRUE(anthropic_json(
+      response, std::optional<std::string>("reason"), &json_str, &error))
+      << error;
+  auto json = nlohmann::json::parse(json_str);
+
+  ASSERT_EQ(json["content"].size(), 2);
+  EXPECT_EQ(json["content"][0]["type"], "thinking");
+  EXPECT_EQ(json["content"][0]["thinking"], "reason");
+  ASSERT_TRUE(json["content"][0].contains("signature"));
+  ASSERT_TRUE(json["content"][0]["signature"].is_string());
+  const auto signature = json["content"][0]["signature"].get<std::string>();
+  EXPECT_FALSE(signature.empty());
+  EXPECT_NE(signature, kOldThinkingSignature);
+  EXPECT_EQ(json["content"][1]["type"], "text");
+  EXPECT_EQ(json["content"][1]["text"], "answer");
+
+  std::string second_json_str;
+  ASSERT_TRUE(anthropic_json(
+      response, std::optional<std::string>("reason"), &second_json_str, &error))
+      << error;
+  auto second_json = nlohmann::json::parse(second_json_str);
+  const auto second_signature =
+      second_json["content"][0]["signature"].get<std::string>();
+  EXPECT_FALSE(second_signature.empty());
+  EXPECT_NE(second_signature, kOldThinkingSignature);
+  EXPECT_NE(second_signature, signature);
+}
+
 TEST(AnthropicAdapterTest, BuildsToolUseAnthropicJson) {
   llm::RequestOutput output;
   output.request_id = "anthropiccmpl-test";
@@ -530,150 +908,6 @@ TEST(AnthropicAdapterTest, BuildsToolUseAnthropicJson) {
   EXPECT_EQ(json["content"][0]["id"], "call_1");
   EXPECT_EQ(json["content"][0]["name"], "get_weather");
   EXPECT_EQ(json["content"][0]["input"]["city"], "Beijing");
-}
-
-TEST(AnthropicAdapterTest, BuildsTextStreamEvents) {
-  AnthropicStreamState state;
-  std::vector<xllm::proto::AnthropicStreamEvent> events;
-
-  llm::RequestOutput first;
-  first.request_id = "anthropiccmpl-test";
-  llm::SequenceOutput first_seq;
-  first_seq.index = 0;
-  first_seq.text = "Hel";
-  first.outputs.push_back(std::move(first_seq));
-
-  auto result =
-      fill_anthropic_stream_events("test-model", first, state, events);
-  ASSERT_TRUE(result.ok) << result.error;
-  ASSERT_EQ(events.size(), 3);
-  EXPECT_EQ(events[0].type(), "message_start");
-  EXPECT_EQ(events[0].message().id(), "anthropiccmpl-test");
-  EXPECT_EQ(events[0].message().usage().input_tokens(), 0);
-  EXPECT_EQ(events[0].message().usage().output_tokens(), 0);
-  EXPECT_EQ(events[1].type(), "content_block_start");
-  EXPECT_EQ(events[1].index(), 0);
-  EXPECT_EQ(events[1].content_block().type(), "text");
-  EXPECT_EQ(events[1].content_block().text(), "");
-  EXPECT_EQ(events[2].type(), "content_block_delta");
-  EXPECT_EQ(events[2].index(), 0);
-  EXPECT_EQ(events[2].delta().type(), "text_delta");
-  EXPECT_EQ(events[2].delta().text(), "Hel");
-
-  llm::RequestOutput second;
-  second.request_id = "anthropiccmpl-test";
-  llm::SequenceOutput second_seq;
-  second_seq.index = 0;
-  second_seq.text = "lo";
-  second.outputs.push_back(std::move(second_seq));
-  events.clear();
-
-  result = fill_anthropic_stream_events("test-model", second, state, events);
-  ASSERT_TRUE(result.ok) << result.error;
-  ASSERT_EQ(events.size(), 1);
-  EXPECT_EQ(events[0].type(), "content_block_delta");
-  EXPECT_EQ(events[0].delta().text(), "lo");
-
-  llm::RequestOutput final;
-  final.request_id = "anthropiccmpl-test";
-  final.finished = true;
-  llm::SequenceOutput final_seq;
-  final_seq.index = 0;
-  final_seq.finish_reason = "stop";
-  final.outputs.push_back(std::move(final_seq));
-  llm::Usage usage;
-  usage.num_prompt_tokens = 3;
-  usage.num_generated_tokens = 5;
-  final.usage = usage;
-  events.clear();
-
-  result = fill_anthropic_stream_events("test-model", final, state, events);
-  ASSERT_TRUE(result.ok) << result.error;
-  ASSERT_EQ(events.size(), 3);
-  EXPECT_EQ(events[0].type(), "content_block_stop");
-  EXPECT_EQ(events[0].index(), 0);
-  EXPECT_EQ(events[1].type(), "message_delta");
-  EXPECT_EQ(events[1].delta().stop_reason(), "end_turn");
-  EXPECT_EQ(events[1].usage().input_tokens(), 3);
-  EXPECT_EQ(events[1].usage().output_tokens(), 5);
-  EXPECT_EQ(events[2].type(), "message_stop");
-
-  std::string sse;
-  std::string error;
-  ASSERT_TRUE(anthropic_event_sse(events[1], &sse, &error)) << error;
-  EXPECT_NE(sse.find("event: message_delta\n"), std::string::npos);
-  EXPECT_NE(sse.find("\ndata: {"), std::string::npos);
-  EXPECT_NE(sse.find("\"stop_reason\":\"end_turn\""), std::string::npos);
-  EXPECT_EQ(sse.substr(sse.size() - 2), "\n\n");
-  EXPECT_EQ(anthropic_done_sse(), "data: [DONE]\n\n");
-}
-
-TEST(AnthropicAdapterTest, BuildsToolStreamEvents) {
-  AnthropicStreamState state;
-  std::vector<xllm::proto::AnthropicStreamEvent> events;
-
-  llm::RequestOutput text;
-  text.request_id = "anthropiccmpl-test";
-  auto result = add_anthropic_text_delta(
-      "test-model", text, "Let me check ", state, events);
-  ASSERT_TRUE(result.ok) << result.error;
-  ASSERT_EQ(events.size(), 3);
-  EXPECT_EQ(events[0].type(), "message_start");
-  EXPECT_EQ(events[1].type(), "content_block_start");
-  EXPECT_EQ(events[1].content_block().type(), "text");
-  EXPECT_EQ(events[2].type(), "content_block_delta");
-  EXPECT_EQ(events[2].delta().type(), "text_delta");
-
-  events.clear();
-  result = add_anthropic_tool_delta(
-      "test-model", text, "call_1", "get_weather", R"({"city")", state, events);
-  ASSERT_TRUE(result.ok) << result.error;
-  ASSERT_EQ(events.size(), 3);
-  EXPECT_EQ(events[0].type(), "content_block_stop");
-  EXPECT_EQ(events[0].index(), 0);
-  EXPECT_EQ(events[1].type(), "content_block_start");
-  EXPECT_EQ(events[1].index(), 1);
-  EXPECT_EQ(events[1].content_block().type(), "tool_use");
-  EXPECT_EQ(events[1].content_block().id(), "call_1");
-  EXPECT_EQ(events[1].content_block().name(), "get_weather");
-  EXPECT_TRUE(events[1].content_block().has_input());
-  EXPECT_EQ(events[2].type(), "content_block_delta");
-  EXPECT_EQ(events[2].index(), 1);
-  EXPECT_EQ(events[2].delta().type(), "input_json_delta");
-  EXPECT_EQ(events[2].delta().partial_json(), R"({"city")");
-
-  events.clear();
-  result = add_anthropic_tool_delta(
-      "test-model", text, "", "", R"(: "Beijing"})", state, events);
-  ASSERT_TRUE(result.ok) << result.error;
-  ASSERT_EQ(events.size(), 1);
-  EXPECT_EQ(events[0].type(), "content_block_delta");
-  EXPECT_EQ(events[0].index(), 1);
-  EXPECT_EQ(events[0].delta().partial_json(), R"(: "Beijing"})");
-
-  llm::RequestOutput final;
-  final.request_id = "anthropiccmpl-test";
-  final.finished = true;
-  llm::SequenceOutput final_seq;
-  final_seq.index = 0;
-  final_seq.finish_reason = "stop";
-  final.outputs.push_back(std::move(final_seq));
-  llm::Usage usage;
-  usage.num_prompt_tokens = 6;
-  usage.num_generated_tokens = 9;
-  final.usage = usage;
-  events.clear();
-
-  result = finish_anthropic_stream("test-model", final, state, events);
-  ASSERT_TRUE(result.ok) << result.error;
-  ASSERT_EQ(events.size(), 3);
-  EXPECT_EQ(events[0].type(), "content_block_stop");
-  EXPECT_EQ(events[0].index(), 1);
-  EXPECT_EQ(events[1].type(), "message_delta");
-  EXPECT_EQ(events[1].delta().stop_reason(), "tool_use");
-  EXPECT_EQ(events[1].usage().input_tokens(), 6);
-  EXPECT_EQ(events[1].usage().output_tokens(), 9);
-  EXPECT_EQ(events[2].type(), "message_stop");
 }
 
 TEST(AnthropicAdapterTest, MapsLengthStopReason) {

--- a/tests/xllm_service/http_service/anthropic_stream_encoder_test.cpp
+++ b/tests/xllm_service/http_service/anthropic_stream_encoder_test.cpp
@@ -1,0 +1,288 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm-service/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "http_service/anthropic_stream_encoder.h"
+
+#include <gtest/gtest.h>
+
+#include <nlohmann/json.hpp>
+#include <string>
+#include <vector>
+
+namespace xllm_service {
+namespace {
+
+llm::RequestOutput make_output(const std::string& request_id) {
+  llm::RequestOutput output;
+  output.request_id = request_id;
+  return output;
+}
+
+// Parses the `data:` payload of one SSE frame into JSON.
+nlohmann::json sse_data_json(const std::string& sse) {
+  const std::string prefix = "data: ";
+  auto pos = sse.find(prefix);
+  EXPECT_NE(pos, std::string::npos) << sse;
+  pos += prefix.size();
+  auto end = sse.find("\n\n", pos);
+  EXPECT_NE(end, std::string::npos) << sse;
+  return nlohmann::json::parse(sse.substr(pos, end - pos));
+}
+
+std::vector<nlohmann::json> to_jsons(const std::vector<std::string>& sse) {
+  std::vector<nlohmann::json> jsons;
+  jsons.reserve(sse.size());
+  for (const auto& frame : sse) {
+    jsons.push_back(sse_data_json(frame));
+  }
+  return jsons;
+}
+
+TEST(AnthropicStreamEncoderTest, PlainTextSingleChunkOpensMessageAndTextBlock) {
+  AnthropicStreamEncoder encoder("test-model");
+  auto output = make_output("anthropiccmpl-test");
+
+  std::vector<std::string> sse;
+  auto result = encoder.on_text(output, "Hel", &sse);
+  ASSERT_TRUE(result.ok) << result.error;
+
+  auto events = to_jsons(sse);
+  ASSERT_EQ(events.size(), 3);
+  EXPECT_EQ(events[0]["type"], "message_start");
+  EXPECT_EQ(events[0]["message"]["id"], "anthropiccmpl-test");
+  EXPECT_EQ(events[0]["message"]["model"], "test-model");
+  EXPECT_EQ(events[1]["type"], "content_block_start");
+  EXPECT_EQ(events[1]["index"], 0);
+  EXPECT_EQ(events[1]["content_block"]["type"], "text");
+  EXPECT_EQ(events[2]["type"], "content_block_delta");
+  EXPECT_EQ(events[2]["index"], 0);
+  EXPECT_EQ(events[2]["delta"]["type"], "text_delta");
+  EXPECT_EQ(events[2]["delta"]["text"], "Hel");
+}
+
+TEST(AnthropicStreamEncoderTest, MessageStartFrameNormalizesNullStopFields) {
+  AnthropicStreamEncoder encoder("test-model");
+  auto output = make_output("anthropiccmpl-test");
+
+  std::vector<std::string> sse;
+  ASSERT_TRUE(encoder.on_text(output, "Hi", &sse).ok);
+  EXPECT_NE(sse[0].find("event: message_start\n"), std::string::npos);
+  auto message_start = sse_data_json(sse[0]);
+  ASSERT_TRUE(message_start["message"].contains("stop_reason"));
+  EXPECT_TRUE(message_start["message"]["stop_reason"].is_null());
+  ASSERT_TRUE(message_start["message"].contains("stop_sequence"));
+  EXPECT_TRUE(message_start["message"]["stop_sequence"].is_null());
+  EXPECT_EQ(message_start["message"]["usage"]["input_tokens"], 0);
+  EXPECT_EQ(message_start["message"]["usage"]["output_tokens"], 0);
+}
+
+TEST(AnthropicStreamEncoderTest, ReasoningThenFinishEmitsSignatureBeforeStop) {
+  AnthropicStreamEncoder encoder("test-model");
+  auto output = make_output("anthropiccmpl-test");
+
+  std::vector<std::string> reasoning;
+  ASSERT_TRUE(encoder.on_reasoning(output, "reason", &reasoning).ok);
+
+  llm::RequestOutput final = make_output("anthropiccmpl-test");
+  final.finished = true;
+  llm::SequenceOutput seq;
+  seq.index = 0;
+  seq.finish_reason = "stop";
+  final.outputs.push_back(std::move(seq));
+
+  std::vector<std::string> done;
+  ASSERT_TRUE(encoder.finish(final, &done).ok);
+  auto events = to_jsons(done);
+  // An unclosed thinking block is sealed with signature_delta then stop.
+  ASSERT_GE(events.size(), 4);
+  EXPECT_EQ(events[0]["type"], "content_block_delta");
+  EXPECT_EQ(events[0]["index"], 0);
+  EXPECT_EQ(events[0]["delta"]["type"], "signature_delta");
+  EXPECT_FALSE(events[0]["delta"]["signature"].get<std::string>().empty());
+  EXPECT_EQ(events[1]["type"], "content_block_stop");
+  EXPECT_EQ(events[1]["index"], 0);
+  EXPECT_EQ(events[2]["type"], "message_delta");
+  EXPECT_EQ(events[3]["type"], "message_stop");
+}
+
+TEST(AnthropicStreamEncoderTest, SecondTextChunkEmitsOnlyDelta) {
+  AnthropicStreamEncoder encoder("test-model");
+  auto output = make_output("anthropiccmpl-test");
+
+  std::vector<std::string> first;
+  ASSERT_TRUE(encoder.on_text(output, "Hel", &first).ok);
+
+  std::vector<std::string> second;
+  ASSERT_TRUE(encoder.on_text(output, "lo", &second).ok);
+
+  auto events = to_jsons(second);
+  ASSERT_EQ(events.size(), 1);
+  EXPECT_EQ(events[0]["type"], "content_block_delta");
+  EXPECT_EQ(events[0]["index"], 0);
+  EXPECT_EQ(events[0]["delta"]["text"], "lo");
+}
+
+TEST(AnthropicStreamEncoderTest, ReasoningThenTextClosesThinkingWithSignature) {
+  AnthropicStreamEncoder encoder("test-model");
+  auto output = make_output("anthropiccmpl-test");
+
+  std::vector<std::string> reasoning;
+  ASSERT_TRUE(encoder.on_reasoning(output, "reason", &reasoning).ok);
+  auto reasoning_events = to_jsons(reasoning);
+  ASSERT_EQ(reasoning_events.size(), 3);
+  EXPECT_EQ(reasoning_events[0]["type"], "message_start");
+  EXPECT_EQ(reasoning_events[1]["type"], "content_block_start");
+  EXPECT_EQ(reasoning_events[1]["index"], 0);
+  EXPECT_EQ(reasoning_events[1]["content_block"]["type"], "thinking");
+  EXPECT_EQ(reasoning_events[2]["type"], "content_block_delta");
+  EXPECT_EQ(reasoning_events[2]["delta"]["type"], "thinking_delta");
+  EXPECT_EQ(reasoning_events[2]["delta"]["thinking"], "reason");
+
+  // Switching to text must close the thinking block with a signature_delta
+  // then a content_block_stop, and open a new text block at the next index.
+  std::vector<std::string> text;
+  ASSERT_TRUE(encoder.on_text(output, "answer", &text).ok);
+  auto text_events = to_jsons(text);
+  ASSERT_EQ(text_events.size(), 4);
+  EXPECT_EQ(text_events[0]["type"], "content_block_delta");
+  EXPECT_EQ(text_events[0]["index"], 0);
+  EXPECT_EQ(text_events[0]["delta"]["type"], "signature_delta");
+  EXPECT_FALSE(text_events[0]["delta"]["signature"].get<std::string>().empty());
+  EXPECT_EQ(text_events[1]["type"], "content_block_stop");
+  EXPECT_EQ(text_events[1]["index"], 0);
+  EXPECT_EQ(text_events[2]["type"], "content_block_start");
+  EXPECT_EQ(text_events[2]["index"], 1);
+  EXPECT_EQ(text_events[2]["content_block"]["type"], "text");
+  EXPECT_EQ(text_events[3]["type"], "content_block_delta");
+  EXPECT_EQ(text_events[3]["index"], 1);
+  EXPECT_EQ(text_events[3]["delta"]["text"], "answer");
+}
+
+TEST(AnthropicStreamEncoderTest, TextThenToolSwitchesBlockAndIncrementsIndex) {
+  AnthropicStreamEncoder encoder("test-model");
+  auto output = make_output("anthropiccmpl-test");
+
+  std::vector<std::string> text;
+  ASSERT_TRUE(encoder.on_text(output, "Let me check ", &text).ok);
+
+  std::vector<std::string> tool;
+  auto result =
+      encoder.on_tool(output, "call_1", "get_weather", R"({"city")", &tool);
+  ASSERT_TRUE(result.ok) << result.error;
+  auto events = to_jsons(tool);
+  ASSERT_EQ(events.size(), 3);
+  EXPECT_EQ(events[0]["type"], "content_block_stop");
+  EXPECT_EQ(events[0]["index"], 0);
+  EXPECT_EQ(events[1]["type"], "content_block_start");
+  EXPECT_EQ(events[1]["index"], 1);
+  EXPECT_EQ(events[1]["content_block"]["type"], "tool_use");
+  EXPECT_EQ(events[1]["content_block"]["id"], "call_1");
+  EXPECT_EQ(events[1]["content_block"]["name"], "get_weather");
+  EXPECT_EQ(events[2]["type"], "content_block_delta");
+  EXPECT_EQ(events[2]["index"], 1);
+  EXPECT_EQ(events[2]["delta"]["type"], "input_json_delta");
+  EXPECT_EQ(events[2]["delta"]["partial_json"], R"({"city")");
+}
+
+TEST(AnthropicStreamEncoderTest, ToolArgumentDeltaContinuesActiveBlock) {
+  AnthropicStreamEncoder encoder("test-model");
+  auto output = make_output("anthropiccmpl-test");
+
+  std::vector<std::string> open;
+  ASSERT_TRUE(
+      encoder.on_tool(output, "call_1", "get_weather", R"({"city")", &open).ok);
+
+  // A follow-up delta with no id/name appends arguments to the open block.
+  std::vector<std::string> more;
+  auto result = encoder.on_tool(output, "", "", R"(: "Beijing"})", &more);
+  ASSERT_TRUE(result.ok) << result.error;
+  auto events = to_jsons(more);
+  ASSERT_EQ(events.size(), 1);
+  EXPECT_EQ(events[0]["type"], "content_block_delta");
+  EXPECT_EQ(events[0]["index"], 0);
+  EXPECT_EQ(events[0]["delta"]["partial_json"], R"(: "Beijing"})");
+}
+
+TEST(AnthropicStreamEncoderTest, ToolArgumentDeltaWithoutActiveBlockRejected) {
+  AnthropicStreamEncoder encoder("test-model");
+  auto output = make_output("anthropiccmpl-test");
+
+  std::vector<std::string> sse;
+  auto result = encoder.on_tool(output, "", "", R"({"command":"ls"})", &sse);
+  EXPECT_FALSE(result.ok);
+  EXPECT_NE(result.error.find("Anthropic tool_use id and name are required"),
+            std::string::npos);
+  EXPECT_TRUE(sse.empty());
+}
+
+TEST(AnthropicStreamEncoderTest, FinishClosesBlockAndEmitsMessageDeltaStop) {
+  AnthropicStreamEncoder encoder("test-model");
+  auto output = make_output("anthropiccmpl-test");
+
+  std::vector<std::string> text;
+  ASSERT_TRUE(encoder.on_text(output, "answer", &text).ok);
+
+  llm::RequestOutput final = make_output("anthropiccmpl-test");
+  final.finished = true;
+  llm::SequenceOutput seq;
+  seq.index = 0;
+  seq.finish_reason = "stop";
+  final.outputs.push_back(std::move(seq));
+  llm::Usage usage;
+  usage.num_prompt_tokens = 3;
+  usage.num_generated_tokens = 5;
+  final.usage = usage;
+
+  std::vector<std::string> done;
+  auto result = encoder.finish(final, &done);
+  ASSERT_TRUE(result.ok) << result.error;
+  auto events = to_jsons(done);
+  ASSERT_EQ(events.size(), 3);
+  EXPECT_EQ(events[0]["type"], "content_block_stop");
+  EXPECT_EQ(events[0]["index"], 0);
+  EXPECT_EQ(events[1]["type"], "message_delta");
+  EXPECT_EQ(events[1]["delta"]["stop_reason"], "end_turn");
+  EXPECT_EQ(events[1]["usage"]["input_tokens"], 3);
+  EXPECT_EQ(events[1]["usage"]["output_tokens"], 5);
+  EXPECT_EQ(events[2]["type"], "message_stop");
+}
+
+TEST(AnthropicStreamEncoderTest, FinishAfterToolUsesToolStopReason) {
+  AnthropicStreamEncoder encoder("test-model");
+  auto output = make_output("anthropiccmpl-test");
+  std::vector<std::string> tool;
+  ASSERT_TRUE(
+      encoder.on_tool(output, "call_1", "get_weather", R"({"city":"X"})", &tool)
+          .ok);
+
+  llm::RequestOutput final = make_output("anthropiccmpl-test");
+  final.finished = true;
+  llm::SequenceOutput seq;
+  seq.index = 0;
+  seq.finish_reason = "stop";
+  final.outputs.push_back(std::move(seq));
+
+  std::vector<std::string> done;
+  ASSERT_TRUE(encoder.finish(final, &done).ok);
+  auto events = to_jsons(done);
+  ASSERT_EQ(events.size(), 3);
+  EXPECT_EQ(events[0]["type"], "content_block_stop");
+  EXPECT_EQ(events[1]["type"], "message_delta");
+  EXPECT_EQ(events[1]["delta"]["stop_reason"], "tool_use");
+  EXPECT_EQ(events[2]["type"], "message_stop");
+}
+
+}  // namespace
+}  // namespace xllm_service

--- a/tests/xllm_service/scheduler/CMakeLists.txt
+++ b/tests/xllm_service/scheduler/CMakeLists.txt
@@ -1,0 +1,11 @@
+include(cc_test)
+
+cc_test(
+  NAME
+    xllm_chat_parse_bridge_test
+  SRCS
+    xllm_chat_parse_bridge_test.cpp
+  DEPS
+    :xllm_chat_parse_runtime
+    GTest::gtest_main
+)

--- a/tests/xllm_service/scheduler/xllm_chat_parse_bridge_test.cpp
+++ b/tests/xllm_service/scheduler/xllm_chat_parse_bridge_test.cpp
@@ -1,0 +1,166 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm-service/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "scheduler/xllm_chat_parse_bridge.h"
+
+#include <gtest/gtest.h>
+
+#include <nlohmann/json.hpp>
+#include <string>
+#include <vector>
+
+#include "xllm/xllm/api_service/stream_output_parser.h"
+
+namespace xllm_service {
+namespace {
+
+std::vector<JsonTool> make_tools() {
+  nlohmann::json params = {{"type", "object"},
+                           {"properties",
+                            {{"content", {{"type", "string"}}},
+                             {"file_path", {{"type", "string"}}}}},
+                           {"required", {"content", "file_path"}}};
+  return {JsonTool("function",
+                   JsonFunction("Write", "Write a local file", params))};
+}
+
+std::vector<JsonTool> make_bash_tools() {
+  nlohmann::json params = {{"type", "object"},
+                           {"properties",
+                            {{"command", {{"type", "string"}}},
+                             {"description", {{"type", "string"}}}}},
+                           {"required", {"command"}}};
+  return {JsonTool("function",
+                   JsonFunction("Bash", "Run a shell command", params))};
+}
+
+TEST(XllmChatParseBridgeTest, ParsesGlmToolCallWithReasoningParserConfigured) {
+  std::string text =
+      "<tool_call>Write<arg_key>content</arg_key><arg_value>hello</arg_value>"
+      "<arg_key>file_path</arg_key><arg_value>/tmp/two_sum.py</arg_value>"
+      "</tool_call>";
+
+  auto result = parse_chat_output_with_xllm(
+      text, make_tools(), "glm5", "stop", "glm47", "glm47", true);
+
+  EXPECT_TRUE(result.text.empty());
+  ASSERT_TRUE(result.tool_calls.has_value());
+  ASSERT_EQ(result.tool_calls->size(), 1);
+  const auto& tool_call = result.tool_calls->Get(0);
+  EXPECT_EQ(tool_call.function().name(), "Write");
+  auto args = nlohmann::json::parse(tool_call.function().arguments());
+  EXPECT_EQ(args["content"], "hello");
+  EXPECT_EQ(args["file_path"], "/tmp/two_sum.py");
+  EXPECT_EQ(result.finish_reason, "tool_calls");
+  EXPECT_FALSE(result.reasoning_content.has_value());
+}
+
+TEST(XllmChatParseBridgeTest, KeepsExplicitThinkingBeforeToolCall) {
+  std::string text =
+      "<think>need file</think>"
+      "<tool_call>Write<arg_key>content</arg_key><arg_value>hello</arg_value>"
+      "<arg_key>file_path</arg_key><arg_value>/tmp/two_sum.py</arg_value>"
+      "</tool_call>";
+
+  auto result = parse_chat_output_with_xllm(
+      text, make_tools(), "glm5", "stop", "glm47", "glm47", true);
+
+  ASSERT_TRUE(result.reasoning_content.has_value());
+  EXPECT_EQ(result.reasoning_content.value(), "need file");
+  ASSERT_TRUE(result.tool_calls.has_value());
+  ASSERT_EQ(result.tool_calls->size(), 1);
+  EXPECT_EQ(result.tool_calls->Get(0).function().name(), "Write");
+  EXPECT_TRUE(result.text.empty());
+}
+
+TEST(XllmChatParseBridgeTest, KeepsImplicitThinkingBeforeToolCall) {
+  std::string text =
+      "need file"
+      "<tool_call>Write<arg_key>content</arg_key><arg_value>hello</arg_value>"
+      "<arg_key>file_path</arg_key><arg_value>/tmp/two_sum.py</arg_value>"
+      "</tool_call></think>";
+
+  auto result = parse_chat_output_with_xllm(
+      text, make_tools(), "glm5", "stop", "glm47", "glm47", true);
+
+  ASSERT_TRUE(result.reasoning_content.has_value());
+  EXPECT_EQ(result.reasoning_content.value(), "need file");
+  ASSERT_TRUE(result.tool_calls.has_value());
+  ASSERT_EQ(result.tool_calls->size(), 1);
+  EXPECT_EQ(result.tool_calls->Get(0).function().name(), "Write");
+  EXPECT_TRUE(result.text.empty());
+}
+
+TEST(XllmChatParseBridgeTest, StreamsAdjacentGlmToolCallsSplitAcrossChunks) {
+  auto stream_parser = create_stream_output_parser_with_xllm(
+      make_bash_tools(), "GLM-5.1-W4A8", "glm47", "", false);
+  auto* parser = stream_parser->get_tool_call_parser(0);
+  ASSERT_NE(parser, nullptr);
+
+  auto first = parser->parse_streaming_increment("<tool_call>Bash<arg_key>");
+  EXPECT_TRUE(first.normal_text.empty());
+  ASSERT_EQ(first.calls.size(), 1);
+  ASSERT_TRUE(first.calls[0].name.has_value());
+  EXPECT_EQ(first.calls[0].name.value(), "Bash");
+  EXPECT_TRUE(first.calls[0].parameters.empty());
+
+  auto second = parser->parse_streaming_increment(
+      "command</arg_key><arg_value>rm hello_world.py</arg_value>"
+      "<arg_key>description</arg_key><arg_value>Delete file</arg_value>"
+      "</tool_call><tool_call>Bash<arg_key>command");
+  EXPECT_TRUE(second.normal_text.empty());
+  ASSERT_FALSE(second.calls.empty());
+  for (const auto& call : second.calls) {
+    EXPECT_FALSE(call.name.has_value());
+  }
+
+  auto third =
+      parser->parse_streaming_increment("</arg_key><arg_value>find .</arg_value>");
+  EXPECT_TRUE(third.normal_text.empty());
+  ASSERT_EQ(third.calls.size(), 1);
+  ASSERT_TRUE(third.calls[0].name.has_value());
+  EXPECT_EQ(third.calls[0].name.value(), "Bash");
+}
+
+TEST(XllmChatParseBridgeTest, StreamsGlmToolNameSplitBeforeArgKey) {
+  auto stream_parser = create_stream_output_parser_with_xllm(
+      make_bash_tools(), "GLM-5.1-W4A8", "glm47", "", false);
+  auto* parser = stream_parser->get_tool_call_parser(0);
+  ASSERT_NE(parser, nullptr);
+
+  auto first = parser->parse_streaming_increment("<tool_call>Bash");
+  EXPECT_TRUE(first.normal_text.empty());
+  EXPECT_TRUE(first.calls.empty());
+
+  auto second = parser->parse_streaming_increment(
+      "<arg_key>command</arg_key><arg_value>"
+      "rm /workspace/xllm-codex/pd-testspace/hello_world.py</arg_value>");
+  EXPECT_TRUE(second.normal_text.empty());
+  ASSERT_EQ(second.calls.size(), 1);
+  ASSERT_TRUE(second.calls[0].name.has_value());
+  EXPECT_EQ(second.calls[0].name.value(), "Bash");
+
+  auto third = parser->parse_streaming_increment(
+      "<arg_key>description</arg_key><arg_value>Delete hello_world.py"
+      "</arg_value></tool_call>");
+  EXPECT_TRUE(third.normal_text.empty());
+  ASSERT_FALSE(third.calls.empty());
+  for (const auto& call : third.calls) {
+    EXPECT_FALSE(call.name.has_value());
+  }
+}
+
+}  // namespace
+}  // namespace xllm_service

--- a/tests/xllm_service/scheduler/xllm_chat_parse_bridge_test.cpp
+++ b/tests/xllm_service/scheduler/xllm_chat_parse_bridge_test.cpp
@@ -126,8 +126,8 @@ TEST(XllmChatParseBridgeTest, StreamsAdjacentGlmToolCallsSplitAcrossChunks) {
     EXPECT_FALSE(call.name.has_value());
   }
 
-  auto third =
-      parser->parse_streaming_increment("</arg_key><arg_value>find .</arg_value>");
+  auto third = parser->parse_streaming_increment(
+      "</arg_key><arg_value>find .</arg_value>");
   EXPECT_TRUE(third.normal_text.empty());
   ASSERT_EQ(third.calls.size(), 1);
   ASSERT_TRUE(third.calls[0].name.has_value());

--- a/xllm_service/chat_template/CMakeLists.txt
+++ b/xllm_service/chat_template/CMakeLists.txt
@@ -15,6 +15,25 @@ cc_library (
     glog::glog
 )
 
+cc_library (
+  NAME
+    message_projection
+  HDRS
+    message_projection.h
+  SRCS
+    message_projection.cpp
+  INCLUDES
+    ${CMAKE_SOURCE_DIR}/third_party/xllm
+    ${CMAKE_SOURCE_DIR}/third_party/xllm/xllm
+    ${CMAKE_SOURCE_DIR}/third_party/xllm/xllm/core
+  DEPS
+    :chat_template
+    glog::glog
+    nlohmann_json::nlohmann_json
+    proto_xllm
+)
+target_link_libraries(message_projection PUBLIC brpc-static leveldb::leveldb ZLIB::ZLIB protobuf::libprotobuf OpenSSL::SSL OpenSSL::Crypto)
+
 cc_test (
   NAME
     chat_template_test

--- a/xllm_service/chat_template/jinja_chat_template.cpp
+++ b/xllm_service/chat_template/jinja_chat_template.cpp
@@ -20,8 +20,115 @@ limitations under the License.
 
 #include <optional>
 #include <string>
+#include <vector>
 
 namespace xllm_service {
+namespace {
+
+bool get_str_field(const nlohmann::ordered_json& json,
+                   const char* key,
+                   std::string* value) {
+  if (!json.contains(key) || !json[key].is_string()) {
+    return false;
+  }
+  *value = json[key].get<std::string>();
+  return true;
+}
+
+std::vector<std::string> thinking_texts(
+    const nlohmann::ordered_json& messages) {
+  std::vector<std::string> texts;
+  for (const auto& message : messages) {
+    if (!message.contains("content") || !message["content"].is_array()) {
+      continue;
+    }
+    for (const auto& item : message["content"]) {
+      std::string type;
+      std::string thinking;
+      if (get_str_field(item, "type", &type) && type == "thinking" &&
+          get_str_field(item, "thinking", &thinking) && !thinking.empty()) {
+        texts.emplace_back(std::move(thinking));
+      }
+    }
+  }
+  return texts;
+}
+
+bool has_all_thinking(const std::string& prompt,
+                      const nlohmann::ordered_json& messages) {
+  for (const auto& thinking : thinking_texts(messages)) {
+    if (prompt.find(thinking) == std::string::npos) {
+      return false;
+    }
+  }
+  return true;
+}
+
+std::string join_parts(const std::vector<std::string>& parts) {
+  std::string text;
+  for (const auto& part : parts) {
+    if (part.empty()) {
+      continue;
+    }
+    if (!text.empty()) {
+      text += '\n';
+    }
+    text += part;
+  }
+  return text;
+}
+
+std::string prompt_content(const nlohmann::ordered_json& content) {
+  std::vector<std::string> parts;
+  for (const auto& item : content) {
+    std::string type;
+    if (!get_str_field(item, "type", &type)) {
+      continue;
+    }
+    if (type == "thinking") {
+      std::string thinking;
+      if (get_str_field(item, "thinking", &thinking) && !thinking.empty()) {
+        parts.emplace_back("<think>" + thinking + "</think>");
+      }
+    } else if (type == "text") {
+      std::string text;
+      if (get_str_field(item, "text", &text) && !text.empty()) {
+        parts.emplace_back(std::move(text));
+      }
+    }
+  }
+  return join_parts(parts);
+}
+
+bool has_thinking_block(const nlohmann::ordered_json& content) {
+  for (const auto& item : content) {
+    std::string type;
+    if (get_str_field(item, "type", &type) && type == "thinking") {
+      return true;
+    }
+  }
+  return false;
+}
+
+nlohmann::ordered_json with_thinking_fallback(
+    const nlohmann::ordered_json& messages) {
+  auto fallback = messages;
+  for (auto& message : fallback) {
+    if (!message.contains("content") || !message["content"].is_array()) {
+      continue;
+    }
+    if (!has_thinking_block(message["content"])) {
+      continue;
+    }
+    auto text = prompt_content(message["content"]);
+    if (!text.empty()) {
+      message["content"] = std::move(text);
+    }
+  }
+  return fallback;
+}
+
+}  // namespace
 
 JinjaChatTemplate::JinjaChatTemplate(const TokenizerArgs& args) : args_(args) {
   try {
@@ -86,6 +193,9 @@ std::optional<std::string> JinjaChatTemplate::apply(
       }
       message_json["tool_calls"] = std::move(tool_calls_json);
     }
+    if (message.reasoning_content.has_value()) {
+      message_json["reasoning_content"] = message.reasoning_content.value();
+    }
     if (!message.tool_call_id.empty()) {
       message_json["tool_call_id"] = message.tool_call_id;
     }
@@ -107,7 +217,18 @@ std::optional<std::string> JinjaChatTemplate::apply(
     tools_json.push_back(tool_json);
   }
   // apply the template
-  return apply(messages_json, tools_json, chat_template_kwargs);
+  auto prompt = apply(messages_json, tools_json, chat_template_kwargs);
+  if (!prompt.has_value() || has_all_thinking(prompt.value(), messages_json)) {
+    return prompt;
+  }
+
+  auto fallback_messages = with_thinking_fallback(messages_json);
+  auto fallback_prompt =
+      apply(fallback_messages, tools_json, chat_template_kwargs);
+  if (fallback_prompt.has_value()) {
+    return fallback_prompt;
+  }
+  return prompt;
 }
 
 std::optional<std::string> JinjaChatTemplate::apply(
@@ -141,6 +262,17 @@ nlohmann::ordered_json JinjaChatTemplate::get_mm_content(
 
     if (item.type == "text") {
       item_json["text"] = item.text;
+    } else if (item.type == "thinking") {
+      item_json["thinking"] = item.thinking;
+      if (!item.signature.empty()) {
+        item_json["signature"] = item.signature;
+      }
+    } else if (item.type == "redacted_thinking") {
+      item_json["data"] = item.data;
+    } else if (item.type == "tool_use") {
+      item_json["id"] = item.id;
+      item_json["name"] = item.name;
+      item_json["input"] = item.input;
     } else {
       item_json[item.type] = "mm place holder";
     }

--- a/xllm_service/chat_template/jinja_chat_template.h
+++ b/xllm_service/chat_template/jinja_chat_template.h
@@ -51,6 +51,12 @@ struct Message {
     std::string type;
 
     std::string text;
+    std::string thinking;
+    std::string signature;
+    std::string data;
+    std::string id;
+    std::string name;
+    nlohmann::ordered_json input = nlohmann::ordered_json::object();
     MMUrl image_url;  // image place holder
 
     MMUrl video_url;  // video place holder
@@ -70,6 +76,7 @@ struct Message {
 
   std::string role;
   Content content;
+  std::optional<std::string> reasoning_content;
   std::optional<ToolCallVec> tool_calls;
   std::string tool_call_id;
 };

--- a/xllm_service/chat_template/jinja_chat_template_test.cpp
+++ b/xllm_service/chat_template/jinja_chat_template_test.cpp
@@ -73,4 +73,100 @@ TEST(JinjaChatTemplate, ApplyChatTemplateKwargs) {
   EXPECT_EQ(result.value(), "hello");
 }
 
+TEST(JinjaChatTemplate, RendersAnthropicOrderedBlocks) {
+  const std::string template_str =
+      "{% for item in messages[0]['content'] %}"
+      "{{ item['type'] }}:"
+      "{% if item['type'] == 'thinking' %}{{ item['thinking'] }}:{{ "
+      "item['signature'] }}{% endif %}"
+      "{% if item['type'] == 'tool_use' %}{{ item['id'] }}:{{ item['name'] "
+      "}}:{{ item['input']['path'] }}{% endif %}"
+      "{% if item['type'] == 'redacted_thinking' %}{{ item['data'] }}{% endif "
+      "%}"
+      "{% if item['type'] == 'text' %}{{ item['text'] }}{% endif %}|"
+      "{% endfor %}"
+      "reasoning={{ messages[0]['reasoning_content'] }}";
+
+  TokenizerArgs args;
+  args.chat_template(template_str);
+  args.bos_token("");
+  args.eos_token("");
+  JinjaChatTemplate template_(args);
+
+  Message::MMContent thinking("thinking");
+  thinking.thinking = "need tool";
+  thinking.signature = "sig_1";
+
+  Message::MMContent tool_use("tool_use");
+  tool_use.id = "toolu_1";
+  tool_use.name = "Read";
+  tool_use.input = {{"path", "a.txt"}};
+
+  Message::MMContent redacted("redacted_thinking");
+  redacted.data = "opaque";
+
+  Message::MMContent text("text", "done");
+
+  Message message("assistant",
+                  Message::MMContentVec{thinking, tool_use, redacted, text});
+  message.reasoning_content = "need tool";
+  ChatMessages messages{message};
+
+  auto result = template_.apply(messages);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(),
+            "thinking:need tool:sig_1|tool_use:toolu_1:Read:a.txt|"
+            "redacted_thinking:opaque|text:done|reasoning=need tool");
+}
+
+TEST(JinjaChatTemplate, RendersPreservedThinkingForStringTemplates) {
+  const std::string template_str =
+      "{% for message in messages %}"
+      "{{ message['role'] }}:"
+      "{% if message['content'] is string %}{{ message['content'] }}{% endif "
+      "%}|"
+      "{% if message.get('tool_calls') %}"
+      "{% for tool_call in message['tool_calls'] %}"
+      "call={{ tool_call['function']['arguments'] }}|"
+      "{% endfor %}"
+      "{% endif %}"
+      "{% endfor %}";
+
+  TokenizerArgs args;
+  args.chat_template(template_str);
+  args.bos_token("");
+  args.eos_token("");
+  JinjaChatTemplate template_(args);
+
+  Message::MMContent thinking("thinking");
+  thinking.thinking = "PTB_marker";
+  thinking.signature = "sig_1";
+
+  Message::MMContent tool_use("tool_use");
+  tool_use.id = "toolu_1";
+  tool_use.name = "preserve_probe";
+  tool_use.input = {{"marker", "TIB_marker"}};
+
+  Message::MMContent text("text", "done");
+
+  Message assistant("assistant",
+                    Message::MMContentVec{thinking, tool_use, text});
+  assistant.reasoning_content = "PTB_marker";
+  Message::ToolCall tool_call;
+  tool_call.id = "toolu_1";
+  tool_call.type = "function";
+  tool_call.function.name = "preserve_probe";
+  tool_call.function.arguments = R"({"marker":"TIB_marker"})";
+  assistant.tool_calls = Message::ToolCallVec{tool_call};
+
+  Message tool("tool", "TRB_marker");
+  tool.tool_call_id = "toolu_1";
+
+  auto result = template_.apply(ChatMessages{assistant, tool});
+  ASSERT_TRUE(result.has_value());
+  EXPECT_NE(result->find("<think>PTB_marker</think>"), std::string::npos);
+  EXPECT_NE(result->find("TIB_marker"), std::string::npos);
+  EXPECT_NE(result->find("TRB_marker"), std::string::npos);
+}
+
 }  // namespace xllm_service

--- a/xllm_service/chat_template/message_projection.cpp
+++ b/xllm_service/chat_template/message_projection.cpp
@@ -1,0 +1,68 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm-service/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "chat_template/message_projection.h"
+
+namespace xllm_service {
+
+std::string flat_text(const Message::MMContentVec& blocks) {
+  std::string text;
+  bool first = true;
+  for (const auto& block : blocks) {
+    if (block.type != "text") {
+      continue;
+    }
+    if (!first) {
+      text += '\n';
+    }
+    text += block.text;
+    first = false;
+  }
+  return text;
+}
+
+bool needs_content_vec(const Message::MMContentVec& blocks) {
+  if (blocks.size() > 1) {
+    return true;
+  }
+  return !blocks.empty() && blocks.front().type != "text";
+}
+
+void to_proto(const Message& msg, xllm::proto::ChatMessage* out) {
+  out->set_role(msg.role);
+  if (std::holds_alternative<std::string>(msg.content)) {
+    out->set_content(std::get<std::string>(msg.content));
+  } else {
+    out->set_content(flat_text(std::get<Message::MMContentVec>(msg.content)));
+  }
+  if (msg.reasoning_content.has_value() && !msg.reasoning_content->empty()) {
+    out->set_reasoning_content(*msg.reasoning_content);
+  }
+  if (msg.tool_calls.has_value()) {
+    for (const auto& tool_call : *msg.tool_calls) {
+      auto* proto_call = out->add_tool_calls();
+      proto_call->set_id(tool_call.id);
+      proto_call->set_type(tool_call.type);
+      auto* proto_function = proto_call->mutable_function();
+      proto_function->set_name(tool_call.function.name);
+      proto_function->set_arguments(tool_call.function.arguments);
+    }
+  }
+  if (!msg.tool_call_id.empty()) {
+    out->set_tool_call_id(msg.tool_call_id);
+  }
+}
+
+}  // namespace xllm_service

--- a/xllm_service/chat_template/message_projection.h
+++ b/xllm_service/chat_template/message_projection.h
@@ -1,0 +1,38 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm-service/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <string>
+
+#include "chat.pb.h"
+#include "chat_template/jinja_chat_template.h"
+
+namespace xllm_service {
+
+// Flattens an ordered multimodal content vector into the single text string
+// that the proto transport carries: only `text` blocks, joined by '\n'.
+std::string flat_text(const Message::MMContentVec& blocks);
+
+// Whether an ordered content vector must be kept as a structured vector on the
+// canonical Message (more than one block, or a single non-text block).
+bool needs_content_vec(const Message::MMContentVec& blocks);
+
+// Projects a canonical Message onto the lossy proto ChatMessage transport.
+// Writes into the pre-allocated `out` (arena friendly). Pure projection: it
+// reproduces, field for field, what the request path used to build by hand.
+void to_proto(const Message& msg, xllm::proto::ChatMessage* out);
+
+}  // namespace xllm_service

--- a/xllm_service/common/CMakeLists.txt
+++ b/xllm_service/common/CMakeLists.txt
@@ -4,6 +4,7 @@ cc_library(
   NAME
   common
   HDRS
+    anthropic_tracer.h
     call_data.h
     closure_guard.h
     concurrent_queue.h
@@ -22,6 +23,7 @@ cc_library(
     xllm/status.h
     xllm/uuid.h
   SRCS
+    anthropic_tracer.cpp
     global_gflags.cpp
     json_reader.cpp
     threadpool.cpp

--- a/xllm_service/common/anthropic_tracer.cpp
+++ b/xllm_service/common/anthropic_tracer.cpp
@@ -1,0 +1,48 @@
+/* Copyright 2025 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm-service/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "common/anthropic_tracer.h"
+
+#include <glog/logging.h>
+
+#include <utility>
+
+#include "common/global_gflags.h"
+
+namespace xllm_service {
+
+AnthropicTracer::AnthropicTracer(Sink sink,
+                                 std::string request_id,
+                                 std::string service_request_id)
+    : sink_(std::move(sink)),
+      request_id_(std::move(request_id)),
+      service_request_id_(std::move(service_request_id)) {}
+
+void AnthropicTracer::trace(const std::string& label,
+                            const std::string& data) const {
+  if (!FLAGS_enable_request_trace) {
+    return;
+  }
+  if (!sink_) {
+    return;
+  }
+  std::string formatted = "[anthropic][" + label + "] " + data;
+  sink_(formatted);
+  LOG(INFO) << "anthropic trace request_id=" << request_id_
+            << " service_request_id=" << service_request_id_
+            << " label=" << label << " data=" << data;
+}
+
+}  // namespace xllm_service

--- a/xllm_service/common/anthropic_tracer.h
+++ b/xllm_service/common/anthropic_tracer.h
@@ -1,0 +1,49 @@
+/* Copyright 2025 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm-service/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <functional>
+#include <string>
+
+namespace xllm_service {
+
+// Centralizes anthropic request-trace formatting, the gflag guard and the LOG
+// context that used to be duplicated across the http_service and scheduler
+// layers. The sink is injected as an adapter: production callers wire it to the
+// per-request trace stream (CallData::trace / Request::trace_callback), tests
+// inject a recording sink.
+class AnthropicTracer {
+ public:
+  // Receives the already-formatted trace string and forwards it to the client
+  // trace stream.
+  using Sink = std::function<void(const std::string& formatted)>;
+
+  AnthropicTracer(Sink sink,
+                  std::string request_id,
+                  std::string service_request_id);
+
+  // Guarded by FLAGS_enable_request_trace. Formats "[anthropic][label] data",
+  // forwards it to the sink and emits a LOG line in one step. No-op when the
+  // flag is disabled or no sink was provided.
+  void trace(const std::string& label, const std::string& data) const;
+
+ private:
+  Sink sink_;
+  std::string request_id_;
+  std::string service_request_id_;
+};
+
+}  // namespace xllm_service

--- a/xllm_service/common/call_data.h
+++ b/xllm_service/common/call_data.h
@@ -113,6 +113,12 @@ class StreamCallData : public CallData {
 
   bool proceed(bool rpc_ok) override { return true; }
 
+  void trace(const std::string& message) {
+    if (trace_callback_) {
+      trace_callback_(message);
+    }
+  }
+
   // For non stream response
   bool write_and_finish(const std::string& attachment /*json string*/) {
     if (trace_callback_) trace_callback_(attachment);

--- a/xllm_service/http_service/CMakeLists.txt
+++ b/xllm_service/http_service/CMakeLists.txt
@@ -28,12 +28,33 @@ cc_library(
     ${CMAKE_SOURCE_DIR}/third_party/xllm/xllm/core
   DEPS
     :chat_template
+    :message_projection
     :common
     glog::glog
     nlohmann_json::nlohmann_json
     proto_xllm
 )
 target_link_libraries(anthropic_adapter PUBLIC brpc-static leveldb::leveldb ZLIB::ZLIB protobuf::libprotobuf OpenSSL::SSL OpenSSL::Crypto)
+
+cc_library(
+  NAME
+    anthropic_stream_encoder
+  HDRS
+    anthropic_stream_encoder.h
+  SRCS
+    anthropic_stream_encoder.cpp
+  INCLUDES
+    ${CMAKE_SOURCE_DIR}/third_party/xllm
+    ${CMAKE_SOURCE_DIR}/third_party/xllm/xllm
+    ${CMAKE_SOURCE_DIR}/third_party/xllm/xllm/core
+  DEPS
+    :anthropic_adapter
+    :common
+    glog::glog
+    nlohmann_json::nlohmann_json
+    proto_xllm
+)
+target_link_libraries(anthropic_stream_encoder PUBLIC brpc-static leveldb::leveldb ZLIB::ZLIB protobuf::libprotobuf OpenSSL::SSL OpenSSL::Crypto)
 
 cc_library(
   NAME

--- a/xllm_service/http_service/anthropic_adapter.cpp
+++ b/xllm_service/http_service/anthropic_adapter.cpp
@@ -20,12 +20,15 @@ limitations under the License.
 
 #include <cstdint>
 #include <nlohmann/json.hpp>
+#include <optional>
 #include <sstream>
+#include <unordered_set>
 #include <utility>
 
 #include "api_service/anthropic_json.h"
 #include "api_service/anthropic_stream_utils.h"
 #include "api_service/chat_json_parser.h"
+#include "chat_template/message_projection.h"
 #include "common/xllm/uuid.h"
 
 namespace xllm_service {
@@ -38,6 +41,10 @@ AnthropicAdaptResult ok_result() { return AnthropicAdaptResult{}; }
 AnthropicAdaptResult error_result(std::string error) {
   return AnthropicAdaptResult{false, std::move(error)};
 }
+
+// Synthetic Anthropic-shaped compatibility value, not a Claude verification
+// signature.
+std::string new_thinking_sig() { return short_uuid.random(); }
 
 std::string system_text(const xllm::proto::AnthropicContentBlockList& blocks) {
   std::string text;
@@ -102,7 +109,6 @@ AnthropicAdaptResult tool_result_text(
 
 AnthropicAdaptResult add_tool_use(
     const xllm::proto::AnthropicContentBlock& block,
-    google::protobuf::RepeatedPtrField<xllm::proto::ToolCall>* proto_tool_calls,
     Message::ToolCallVec* tool_calls) {
   if (!block.has_id()) {
     return error_result("Anthropic tool_use id is required.");
@@ -110,14 +116,6 @@ AnthropicAdaptResult add_tool_use(
   if (!block.has_name()) {
     return error_result("Anthropic tool_use name is required.");
   }
-
-  auto* proto_call = proto_tool_calls->Add();
-  proto_call->set_id(block.id());
-  proto_call->set_type("function");
-  auto* proto_function = proto_call->mutable_function();
-  proto_function->set_name(block.name());
-  proto_function->set_arguments(block.has_input() ? struct_json(block.input())
-                                                  : "{}");
 
   Message::ToolCall tool_call;
   tool_call.id = block.id();
@@ -129,14 +127,63 @@ AnthropicAdaptResult add_tool_use(
   return ok_result();
 }
 
+bool is_empty_bash_tool_use(const xllm::proto::AnthropicContentBlock& block) {
+  return block.has_name() && block.name() == "Bash" &&
+         (!block.has_input() || block.input().fields().empty());
+}
+
+nlohmann::ordered_json struct_to_json(
+    const google::protobuf::Struct& proto_struct) {
+  return nlohmann::ordered_json::parse(struct_json(proto_struct));
+}
+
+Message::MMContent thinking_content(
+    const xllm::proto::AnthropicContentBlock& block) {
+  Message::MMContent content("thinking");
+  if (block.has_thinking()) {
+    content.thinking = block.thinking();
+  }
+  if (block.has_signature()) {
+    content.signature = block.signature();
+  }
+  return content;
+}
+
+Message::MMContent redacted_content(
+    const xllm::proto::AnthropicContentBlock& block) {
+  Message::MMContent content("redacted_thinking");
+  if (block.has_data()) {
+    content.data = block.data();
+  }
+  return content;
+}
+
+Message::MMContent tool_use_content(
+    const xllm::proto::AnthropicContentBlock& block) {
+  Message::MMContent content("tool_use");
+  if (block.has_id()) {
+    content.id = block.id();
+  }
+  if (block.has_name()) {
+    content.name = block.name();
+  }
+  if (block.has_input()) {
+    content.input = struct_to_json(block.input());
+  }
+  return content;
+}
+
 AnthropicAdaptResult add_tool_result(
     const xllm::proto::AnthropicContentBlock& block,
     const std::string& role,
-    xllm::proto::ChatRequest* chat_request,
+    const std::unordered_set<std::string>& skipped_tool_use_ids,
     ChatMessages* messages,
     Message::MMContentVec* content_parts) {
   if (!block.has_id()) {
     return error_result("Anthropic tool_result tool_use_id is required.");
+  }
+  if (skipped_tool_use_ids.find(block.id()) != skipped_tool_use_ids.end()) {
+    return ok_result();
   }
 
   std::string result_text;
@@ -146,11 +193,6 @@ AnthropicAdaptResult add_tool_result(
   }
 
   if (role == "user") {
-    auto* tool_msg = chat_request->add_messages();
-    tool_msg->set_role("tool");
-    tool_msg->set_content(result_text);
-    tool_msg->set_tool_call_id(block.id());
-
     Message message("tool", result_text);
     message.tool_call_id = block.id();
     messages->emplace_back(std::move(message));
@@ -206,12 +248,8 @@ std::string tool_choice(const xllm::proto::AnthropicMessagesRequest& request) {
 
 AnthropicAdaptResult add_system_msg(
     const xllm::proto::AnthropicMessagesRequest& request,
-    xllm::proto::ChatRequest* chat_request,
     ChatMessages* messages) {
   if (request.has_system_string()) {
-    auto* message = chat_request->add_messages();
-    message->set_role("system");
-    message->set_content(request.system_string());
     messages->emplace_back("system", request.system_string());
     return ok_result();
   }
@@ -228,76 +266,74 @@ AnthropicAdaptResult add_system_msg(
   if (text.empty()) {
     return ok_result();
   }
-  auto* message = chat_request->add_messages();
-  message->set_role("system");
-  message->set_content(text);
   messages->emplace_back("system", std::move(text));
   return ok_result();
 }
 
 AnthropicAdaptResult add_content_msg(
     const xllm::proto::AnthropicMessage& src_message,
-    xllm::proto::ChatRequest* chat_request,
-    ChatMessages* messages) {
+    ChatMessages* messages,
+    std::unordered_set<std::string>* skipped_tool_use_ids) {
   switch (src_message.message_content_case()) {
     case xllm::proto::AnthropicMessage::kContentString: {
-      auto* message = chat_request->add_messages();
-      message->set_role(src_message.role());
-      message->set_content(src_message.content_string());
       messages->emplace_back(src_message.role(), src_message.content_string());
       return ok_result();
     }
     case xllm::proto::AnthropicMessage::kContentBlocks: {
-      Message::MMContentVec mm_content;
+      Message::MMContentVec ordered_content;
       Message::ToolCallVec tool_calls;
-      google::protobuf::RepeatedPtrField<xllm::proto::ToolCall>
-          proto_tool_calls;
+      std::string reasoning_content;
       for (const auto& block : src_message.content_blocks().blocks()) {
         if (block.type() == "text" && block.has_text()) {
-          mm_content.emplace_back("text", block.text());
+          ordered_content.emplace_back("text", block.text());
         } else if (block.type() == "tool_use") {
-          auto result = add_tool_use(block, &proto_tool_calls, &tool_calls);
+          if (is_empty_bash_tool_use(block)) {
+            if (block.has_id()) {
+              skipped_tool_use_ids->insert(block.id());
+            }
+            continue;
+          }
+          auto result = add_tool_use(block, &tool_calls);
           if (!result.ok) {
             return result;
           }
+          ordered_content.emplace_back(tool_use_content(block));
         } else if (block.type() == "tool_result") {
-          auto result = add_tool_result(
-              block, src_message.role(), chat_request, messages, &mm_content);
+          auto result = add_tool_result(block,
+                                        src_message.role(),
+                                        *skipped_tool_use_ids,
+                                        messages,
+                                        &ordered_content);
           if (!result.ok) {
             return result;
           }
+        } else if (block.type() == "thinking") {
+          ordered_content.emplace_back(thinking_content(block));
+          if (block.has_thinking()) {
+            reasoning_content += block.thinking();
+          }
+        } else if (block.type() == "redacted_thinking") {
+          ordered_content.emplace_back(redacted_content(block));
         } else {
           return error_result("Unsupported Anthropic content block type: " +
                               block.type());
         }
       }
 
-      std::string flat_text;
-      bool first = true;
-      for (const auto& block : mm_content) {
-        if (!first) {
-          flat_text += '\n';
-        }
-        flat_text += block.text;
-        first = false;
-      }
-      if (flat_text.empty() && proto_tool_calls.empty()) {
+      const std::string text = flat_text(ordered_content);
+      if (ordered_content.empty() && tool_calls.empty()) {
         return ok_result();
       }
 
-      auto* message = chat_request->add_messages();
-      message->set_role(src_message.role());
-      message->set_content(flat_text);
-      for (const auto& tool_call : proto_tool_calls) {
-        message->add_tool_calls()->CopyFrom(tool_call);
+      Message dst_message(src_message.role(), text);
+      if (!reasoning_content.empty()) {
+        dst_message.reasoning_content = reasoning_content;
       }
-
-      Message dst_message(src_message.role(), flat_text);
       if (!tool_calls.empty()) {
         dst_message.tool_calls = std::move(tool_calls);
       }
-      if (mm_content.size() > 1) {
-        dst_message.content = std::move(mm_content);
+      if (needs_content_vec(ordered_content)) {
+        dst_message.content = std::move(ordered_content);
       }
       messages->emplace_back(std::move(dst_message));
       return ok_result();
@@ -346,128 +382,43 @@ void fill_usage(const llm::RequestOutput& request_output,
       static_cast<int32_t>(usage.num_generated_tokens));
 }
 
-void add_message_start(const std::string& model,
-                       const llm::RequestOutput& request_output,
-                       AnthropicStreamState* state,
-                       std::vector<xllm::proto::AnthropicStreamEvent>* events) {
-  if (state->message_started) {
-    return;
+bool normalize_stream_event_json(const xllm::proto::AnthropicStreamEvent& event,
+                                 std::string* json,
+                                 std::string* error) {
+  try {
+    nlohmann::json parsed = nlohmann::json::parse(*json);
+
+    if (event.type() == "message_start" && event.has_message()) {
+      auto& message = parsed["message"];
+      if (!event.message().has_stop_reason()) {
+        message["stop_reason"] = nullptr;
+      }
+      if (!event.message().has_stop_sequence()) {
+        message["stop_sequence"] = nullptr;
+      }
+      auto& usage = message["usage"];
+      usage["input_tokens"] = event.message().usage().input_tokens();
+      usage["output_tokens"] = event.message().usage().output_tokens();
+    }
+
+    if (event.type() == "message_delta" && event.has_delta()) {
+      auto& delta = parsed["delta"];
+      if (!event.delta().has_stop_sequence()) {
+        delta["stop_sequence"] = nullptr;
+      }
+      if (event.has_usage()) {
+        auto& usage = parsed["usage"];
+        usage["input_tokens"] = event.usage().input_tokens();
+        usage["output_tokens"] = event.usage().output_tokens();
+      }
+    }
+
+    *json = parsed.dump();
+    return true;
+  } catch (const std::exception& e) {
+    *error = e.what();
+    return false;
   }
-
-  xllm::proto::AnthropicStreamEvent event;
-  event.set_type("message_start");
-  auto* message = event.mutable_message();
-  message->set_id(request_output.request_id);
-  message->set_type("message");
-  message->set_role("assistant");
-  message->set_model(model);
-  auto* usage = message->mutable_usage();
-  usage->set_input_tokens(0);
-  usage->set_output_tokens(0);
-
-  events->push_back(std::move(event));
-  state->message_started = true;
-}
-
-void add_block_stop(AnthropicStreamState* state,
-                    std::vector<xllm::proto::AnthropicStreamEvent>* events) {
-  if (state->content_block_index < 0) {
-    return;
-  }
-
-  xllm::proto::AnthropicStreamEvent event;
-  event.set_type("content_block_stop");
-  event.set_index(state->content_block_index);
-  events->push_back(std::move(event));
-}
-
-void start_text_block(AnthropicStreamState* state,
-                      std::vector<xllm::proto::AnthropicStreamEvent>* events) {
-  if (state->last_content_block_type == "text") {
-    return;
-  }
-  if (!state->last_content_block_type.empty()) {
-    add_block_stop(state, events);
-  }
-
-  state->last_content_block_type = "text";
-  ++state->content_block_index;
-
-  xllm::proto::AnthropicStreamEvent event;
-  event.set_type("content_block_start");
-  event.set_index(state->content_block_index);
-  auto* content_block = event.mutable_content_block();
-  content_block->set_type("text");
-  content_block->set_text("");
-  events->push_back(std::move(event));
-}
-
-void start_tool_block(const std::string& tool_call_id,
-                      const std::string& function_name,
-                      AnthropicStreamState* state,
-                      std::vector<xllm::proto::AnthropicStreamEvent>* events) {
-  if (!state->last_content_block_type.empty()) {
-    add_block_stop(state, events);
-  }
-
-  state->last_content_block_type = "tool_use";
-  ++state->content_block_index;
-
-  xllm::proto::AnthropicStreamEvent event;
-  event.set_type("content_block_start");
-  event.set_index(state->content_block_index);
-  auto* content_block = event.mutable_content_block();
-  content_block->set_type("tool_use");
-  if (!tool_call_id.empty()) {
-    content_block->set_id(tool_call_id);
-  }
-  if (!function_name.empty()) {
-    content_block->set_name(function_name);
-  }
-  content_block->mutable_input();
-  events->push_back(std::move(event));
-}
-
-void add_text_delta(const std::string& text,
-                    const AnthropicStreamState& state,
-                    std::vector<xllm::proto::AnthropicStreamEvent>* events) {
-  xllm::proto::AnthropicStreamEvent event;
-  event.set_type("content_block_delta");
-  event.set_index(state.content_block_index);
-  auto* delta = event.mutable_delta();
-  delta->set_type("text_delta");
-  delta->set_text(text);
-  events->push_back(std::move(event));
-}
-
-void add_message_delta(const llm::RequestOutput& request_output,
-                       const std::string& finish_reason,
-                       bool has_tool_call,
-                       std::vector<xllm::proto::AnthropicStreamEvent>* events) {
-  xllm::proto::AnthropicStreamEvent event;
-  event.set_type("message_delta");
-  auto* delta = event.mutable_delta();
-  delta->set_stop_reason(xllm::api_service::get_stream_stop_reason(
-      true, has_tool_call, finish_reason));
-
-  auto* usage = event.mutable_usage();
-  if (request_output.usage.has_value()) {
-    const auto& source_usage = request_output.usage.value();
-    usage->set_input_tokens(
-        static_cast<int32_t>(source_usage.num_prompt_tokens));
-    usage->set_output_tokens(
-        static_cast<int32_t>(source_usage.num_generated_tokens));
-  } else {
-    usage->set_input_tokens(0);
-    usage->set_output_tokens(0);
-  }
-  events->push_back(std::move(event));
-}
-
-void add_message_stop(std::vector<xllm::proto::AnthropicStreamEvent>* events) {
-  xllm::proto::AnthropicStreamEvent event;
-  event.set_type("message_stop");
-  events->push_back(std::move(event));
 }
 
 }  // namespace
@@ -517,19 +468,24 @@ AnthropicAdaptResult fill_chat_req(
   }
   chat_request->set_tool_choice(tool_choice(anthropic_request));
 
-  auto system_result =
-      add_system_msg(anthropic_request, chat_request, messages);
+  auto system_result = add_system_msg(anthropic_request, messages);
   if (!system_result.ok) {
     return system_result;
   }
+  std::unordered_set<std::string> skipped_tool_use_ids;
   for (const auto& message : anthropic_request.messages()) {
-    auto content_result = add_content_msg(message, chat_request, messages);
+    auto content_result =
+        add_content_msg(message, messages, &skipped_tool_use_ids);
     if (!content_result.ok) {
       return content_result;
     }
   }
   if (messages->empty()) {
     return error_result("Messages is empty!");
+  }
+
+  for (const auto& message : *messages) {
+    to_proto(message, chat_request->add_messages());
   }
   return ok_result();
 }
@@ -583,90 +539,6 @@ AnthropicAdaptResult fill_anthropic_resp(
   return ok_result();
 }
 
-AnthropicAdaptResult fill_anthropic_stream_events(
-    const std::string& model,
-    const llm::RequestOutput& request_output,
-    AnthropicStreamState& state,
-    std::vector<xllm::proto::AnthropicStreamEvent>& events) {
-  for (const auto& seq_output : request_output.outputs) {
-    if (!seq_output.text.empty()) {
-      auto result = add_anthropic_text_delta(
-          model, request_output, seq_output.text, state, events);
-      if (!result.ok) {
-        return result;
-      }
-    }
-  }
-
-  if (request_output.finished) {
-    return finish_anthropic_stream(model, request_output, state, events);
-  }
-
-  return ok_result();
-}
-
-AnthropicAdaptResult add_anthropic_text_delta(
-    const std::string& model,
-    const llm::RequestOutput& request_output,
-    const std::string& text,
-    AnthropicStreamState& state,
-    std::vector<xllm::proto::AnthropicStreamEvent>& events) {
-  if (text.empty()) {
-    return ok_result();
-  }
-
-  add_message_start(model, request_output, &state, &events);
-  start_text_block(&state, &events);
-  add_text_delta(text, state, &events);
-  return ok_result();
-}
-
-AnthropicAdaptResult add_anthropic_tool_delta(
-    const std::string& model,
-    const llm::RequestOutput& request_output,
-    const std::string& tool_call_id,
-    const std::string& function_name,
-    const std::string& arguments,
-    AnthropicStreamState& state,
-    std::vector<xllm::proto::AnthropicStreamEvent>& events) {
-  add_message_start(model, request_output, &state, &events);
-  state.has_tool_call = true;
-  const bool starts_new_call = !function_name.empty();
-  if (state.last_content_block_type != "tool_use" || starts_new_call) {
-    start_tool_block(tool_call_id, function_name, &state, &events);
-  }
-
-  auto event = xllm::api_service::make_input_json_delta_event(
-      state.content_block_index, arguments);
-  if (event.has_value()) {
-    events.push_back(std::move(event.value()));
-  }
-  return ok_result();
-}
-
-AnthropicAdaptResult finish_anthropic_stream(
-    const std::string& model,
-    const llm::RequestOutput& request_output,
-    AnthropicStreamState& state,
-    std::vector<xllm::proto::AnthropicStreamEvent>& events) {
-  add_message_start(model, request_output, &state, &events);
-  if (state.content_block_index >= 0) {
-    add_block_stop(&state, &events);
-    state.last_content_block_type.clear();
-  }
-
-  std::string finish_reason;
-  for (const auto& seq_output : request_output.outputs) {
-    if (seq_output.finish_reason.has_value()) {
-      finish_reason = seq_output.finish_reason.value();
-    }
-  }
-  add_message_delta(
-      request_output, finish_reason, state.has_tool_call, &events);
-  add_message_stop(&events);
-  return ok_result();
-}
-
 bool anthropic_json(const xllm::proto::AnthropicMessagesResponse& response,
                     std::string* json,
                     std::string* error) {
@@ -675,6 +547,35 @@ bool anthropic_json(const xllm::proto::AnthropicMessagesResponse& response,
   options.jsonify_empty_array = true;
   return xllm::api_service::proto_to_anthropic_json(
       response, options, json, error);
+}
+
+bool anthropic_json(const xllm::proto::AnthropicMessagesResponse& response,
+                    const std::optional<std::string>& thinking,
+                    std::string* json,
+                    std::string* error) {
+  if (!anthropic_json(response, json, error)) {
+    return false;
+  }
+  if (!thinking.has_value() || thinking->empty()) {
+    return true;
+  }
+
+  try {
+    nlohmann::json parsed = nlohmann::json::parse(*json);
+    if (!parsed.contains("content") || !parsed["content"].is_array()) {
+      parsed["content"] = nlohmann::json::array();
+    }
+    nlohmann::json thinking_block = {{"type", "thinking"},
+                                     {"thinking", thinking.value()},
+                                     {"signature", new_thinking_sig()}};
+    parsed["content"].insert(parsed["content"].begin(),
+                             std::move(thinking_block));
+    *json = parsed.dump();
+    return true;
+  } catch (const std::exception& e) {
+    *error = e.what();
+    return false;
+  }
 }
 
 bool anthropic_event_sse(const xllm::proto::AnthropicStreamEvent& event,
@@ -687,6 +588,9 @@ bool anthropic_event_sse(const xllm::proto::AnthropicStreamEvent& event,
   std::string json;
   if (!xllm::api_service::proto_to_anthropic_json(
           event, options, &json, error)) {
+    return false;
+  }
+  if (!normalize_stream_event_json(event, &json, error)) {
     return false;
   }
   *sse = "event: " + event.type() + "\ndata: " + json + "\n\n";

--- a/xllm_service/http_service/anthropic_adapter.h
+++ b/xllm_service/http_service/anthropic_adapter.h
@@ -16,6 +16,7 @@ limitations under the License.
 #pragma once
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -29,13 +30,6 @@ namespace xllm_service {
 struct AnthropicAdaptResult {
   bool ok = true;
   std::string error;
-};
-
-struct AnthropicStreamState {
-  bool message_started = false;
-  bool has_tool_call = false;
-  int32_t content_block_index = -1;
-  std::string last_content_block_type;
 };
 
 std::string new_anthropic_id();
@@ -56,35 +50,12 @@ AnthropicAdaptResult fill_anthropic_resp(
     const google::protobuf::RepeatedPtrField<xllm::proto::ToolCall>*
         tool_calls = nullptr);
 
-AnthropicAdaptResult fill_anthropic_stream_events(
-    const std::string& model,
-    const llm::RequestOutput& request_output,
-    AnthropicStreamState& state,
-    std::vector<xllm::proto::AnthropicStreamEvent>& events);
-
-AnthropicAdaptResult add_anthropic_text_delta(
-    const std::string& model,
-    const llm::RequestOutput& request_output,
-    const std::string& text,
-    AnthropicStreamState& state,
-    std::vector<xllm::proto::AnthropicStreamEvent>& events);
-
-AnthropicAdaptResult add_anthropic_tool_delta(
-    const std::string& model,
-    const llm::RequestOutput& request_output,
-    const std::string& tool_call_id,
-    const std::string& function_name,
-    const std::string& arguments,
-    AnthropicStreamState& state,
-    std::vector<xllm::proto::AnthropicStreamEvent>& events);
-
-AnthropicAdaptResult finish_anthropic_stream(
-    const std::string& model,
-    const llm::RequestOutput& request_output,
-    AnthropicStreamState& state,
-    std::vector<xllm::proto::AnthropicStreamEvent>& events);
+bool anthropic_json(const xllm::proto::AnthropicMessagesResponse& response,
+                    std::string* json,
+                    std::string* error);
 
 bool anthropic_json(const xllm::proto::AnthropicMessagesResponse& response,
+                    const std::optional<std::string>& thinking,
                     std::string* json,
                     std::string* error);
 

--- a/xllm_service/http_service/anthropic_stream_encoder.cpp
+++ b/xllm_service/http_service/anthropic_stream_encoder.cpp
@@ -1,0 +1,336 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm-service/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "http_service/anthropic_stream_encoder.h"
+
+#include <nlohmann/json.hpp>
+#include <utility>
+
+#include "api_service/anthropic_stream_utils.h"
+#include "common/xllm/uuid.h"
+
+namespace xllm_service {
+namespace {
+
+thread_local llm::ShortUUID short_uuid;
+
+AnthropicAdaptResult ok_result() { return AnthropicAdaptResult{}; }
+
+AnthropicAdaptResult error_result(std::string error) {
+  return AnthropicAdaptResult{false, std::move(error)};
+}
+
+// Synthetic Anthropic-shaped compatibility value, not a Claude verification
+// signature.
+std::string new_thinking_sig() { return short_uuid.random(); }
+
+std::string json_sse(const std::string& event_type,
+                     const nlohmann::json& event) {
+  return "event: " + event_type + "\ndata: " + event.dump() + "\n\n";
+}
+
+bool append_proto_sse(
+    const std::vector<xllm::proto::AnthropicStreamEvent>& events,
+    std::vector<std::string>* sse_events,
+    std::string* error) {
+  for (const auto& event : events) {
+    std::string sse;
+    if (!anthropic_event_sse(event, &sse, error)) {
+      return false;
+    }
+    sse_events->push_back(std::move(sse));
+  }
+  return true;
+}
+
+}  // namespace
+
+AnthropicStreamEncoder::AnthropicStreamEncoder(std::string model)
+    : model_(std::move(model)) {}
+
+void AnthropicStreamEncoder::add_message_start(
+    const llm::RequestOutput& request_output,
+    std::vector<xllm::proto::AnthropicStreamEvent>* events) {
+  if (state_.message_started) {
+    return;
+  }
+
+  xllm::proto::AnthropicStreamEvent event;
+  event.set_type("message_start");
+  auto* message = event.mutable_message();
+  message->set_id(request_output.request_id);
+  message->set_type("message");
+  message->set_role("assistant");
+  message->set_model(model_);
+  auto* usage = message->mutable_usage();
+  usage->set_input_tokens(0);
+  usage->set_output_tokens(0);
+
+  events->push_back(std::move(event));
+  state_.message_started = true;
+}
+
+void AnthropicStreamEncoder::add_sig_delta(
+    std::vector<xllm::proto::AnthropicStreamEvent>* events) {
+  xllm::proto::AnthropicStreamEvent event;
+  event.set_type("content_block_delta");
+  event.set_index(state_.content_block_index);
+  auto* delta = event.mutable_delta();
+  delta->set_type("signature_delta");
+  delta->set_signature(state_.thinking_signature);
+  events->push_back(std::move(event));
+}
+
+void AnthropicStreamEncoder::add_block_stop(
+    std::vector<xllm::proto::AnthropicStreamEvent>* events) {
+  if (state_.content_block_index < 0) {
+    return;
+  }
+
+  if (state_.last_content_block_type == "thinking") {
+    if (state_.thinking_signature.empty()) {
+      state_.thinking_signature = new_thinking_sig();
+    }
+    add_sig_delta(events);
+  }
+
+  xllm::proto::AnthropicStreamEvent event;
+  event.set_type("content_block_stop");
+  event.set_index(state_.content_block_index);
+  events->push_back(std::move(event));
+  state_.thinking_signature.clear();
+}
+
+void AnthropicStreamEncoder::start_text_block(
+    std::vector<xllm::proto::AnthropicStreamEvent>* events) {
+  if (state_.last_content_block_type == "text") {
+    return;
+  }
+  if (!state_.last_content_block_type.empty()) {
+    add_block_stop(events);
+  }
+
+  state_.last_content_block_type = "text";
+  ++state_.content_block_index;
+
+  xllm::proto::AnthropicStreamEvent event;
+  event.set_type("content_block_start");
+  event.set_index(state_.content_block_index);
+  auto* content_block = event.mutable_content_block();
+  content_block->set_type("text");
+  content_block->set_text("");
+  events->push_back(std::move(event));
+}
+
+void AnthropicStreamEncoder::start_tool_block(
+    const std::string& tool_call_id,
+    const std::string& function_name,
+    std::vector<xllm::proto::AnthropicStreamEvent>* events) {
+  if (!state_.last_content_block_type.empty()) {
+    add_block_stop(events);
+  }
+
+  state_.last_content_block_type = "tool_use";
+  ++state_.content_block_index;
+
+  xllm::proto::AnthropicStreamEvent event;
+  event.set_type("content_block_start");
+  event.set_index(state_.content_block_index);
+  auto* content_block = event.mutable_content_block();
+  content_block->set_type("tool_use");
+  if (!tool_call_id.empty()) {
+    content_block->set_id(tool_call_id);
+  }
+  if (!function_name.empty()) {
+    content_block->set_name(function_name);
+  }
+  content_block->mutable_input();
+  events->push_back(std::move(event));
+}
+
+void AnthropicStreamEncoder::add_text_delta(
+    const std::string& text,
+    std::vector<xllm::proto::AnthropicStreamEvent>* events) {
+  xllm::proto::AnthropicStreamEvent event;
+  event.set_type("content_block_delta");
+  event.set_index(state_.content_block_index);
+  auto* delta = event.mutable_delta();
+  delta->set_type("text_delta");
+  delta->set_text(text);
+  events->push_back(std::move(event));
+}
+
+void AnthropicStreamEncoder::start_thinking_block(
+    std::vector<std::string>* sse_events) {
+  if (state_.last_content_block_type == "thinking") {
+    return;
+  }
+
+  state_.last_content_block_type = "thinking";
+  state_.thinking_signature = new_thinking_sig();
+  ++state_.content_block_index;
+
+  nlohmann::json event = {
+      {"type", "content_block_start"},
+      {"index", state_.content_block_index},
+      {"content_block", {{"type", "thinking"}, {"thinking", ""}}}};
+  sse_events->push_back(json_sse("content_block_start", event));
+}
+
+void AnthropicStreamEncoder::add_thinking_delta(
+    const std::string& thinking,
+    std::vector<std::string>* sse_events) {
+  nlohmann::json event = {
+      {"type", "content_block_delta"},
+      {"index", state_.content_block_index},
+      {"delta", {{"type", "thinking_delta"}, {"thinking", thinking}}}};
+  sse_events->push_back(json_sse("content_block_delta", event));
+}
+
+void AnthropicStreamEncoder::add_message_delta(
+    const llm::RequestOutput& request_output,
+    const std::string& finish_reason,
+    std::vector<xllm::proto::AnthropicStreamEvent>* events) {
+  xllm::proto::AnthropicStreamEvent event;
+  event.set_type("message_delta");
+  auto* delta = event.mutable_delta();
+  delta->set_stop_reason(xllm::api_service::get_stream_stop_reason(
+      true, state_.has_tool_call, finish_reason));
+
+  auto* usage = event.mutable_usage();
+  if (request_output.usage.has_value()) {
+    const auto& source_usage = request_output.usage.value();
+    usage->set_input_tokens(
+        static_cast<int32_t>(source_usage.num_prompt_tokens));
+    usage->set_output_tokens(
+        static_cast<int32_t>(source_usage.num_generated_tokens));
+  } else {
+    usage->set_input_tokens(0);
+    usage->set_output_tokens(0);
+  }
+  events->push_back(std::move(event));
+}
+
+void AnthropicStreamEncoder::add_message_stop(
+    std::vector<xllm::proto::AnthropicStreamEvent>* events) {
+  xllm::proto::AnthropicStreamEvent event;
+  event.set_type("message_stop");
+  events->push_back(std::move(event));
+}
+
+AnthropicAdaptResult AnthropicStreamEncoder::on_text(
+    const llm::RequestOutput& output,
+    const std::string& text,
+    std::vector<std::string>* out) {
+  if (text.empty()) {
+    return ok_result();
+  }
+
+  std::vector<xllm::proto::AnthropicStreamEvent> events;
+  add_message_start(output, &events);
+  start_text_block(&events);
+  add_text_delta(text, &events);
+
+  std::string error;
+  if (!append_proto_sse(events, out, &error)) {
+    return error_result(error);
+  }
+  return ok_result();
+}
+
+AnthropicAdaptResult AnthropicStreamEncoder::on_reasoning(
+    const llm::RequestOutput& output,
+    const std::string& thinking,
+    std::vector<std::string>* out) {
+  if (thinking.empty()) {
+    return ok_result();
+  }
+
+  std::vector<xllm::proto::AnthropicStreamEvent> prefix_events;
+  add_message_start(output, &prefix_events);
+  if (!state_.last_content_block_type.empty() &&
+      state_.last_content_block_type != "thinking") {
+    add_block_stop(&prefix_events);
+  }
+
+  std::string error;
+  if (!append_proto_sse(prefix_events, out, &error)) {
+    return error_result(error);
+  }
+
+  start_thinking_block(out);
+  add_thinking_delta(thinking, out);
+  return ok_result();
+}
+
+AnthropicAdaptResult AnthropicStreamEncoder::on_tool(
+    const llm::RequestOutput& output,
+    const std::string& tool_call_id,
+    const std::string& function_name,
+    const std::string& arguments,
+    std::vector<std::string>* out) {
+  const bool starts_new_call = !function_name.empty();
+  if ((state_.last_content_block_type != "tool_use" || starts_new_call) &&
+      (tool_call_id.empty() || function_name.empty())) {
+    return error_result("Anthropic tool_use id and name are required.");
+  }
+
+  std::vector<xllm::proto::AnthropicStreamEvent> events;
+  add_message_start(output, &events);
+  state_.has_tool_call = true;
+  if (state_.last_content_block_type != "tool_use" || starts_new_call) {
+    start_tool_block(tool_call_id, function_name, &events);
+  }
+
+  auto event = xllm::api_service::make_input_json_delta_event(
+      state_.content_block_index, arguments);
+  if (event.has_value()) {
+    events.push_back(std::move(event.value()));
+  }
+
+  std::string error;
+  if (!append_proto_sse(events, out, &error)) {
+    return error_result(error);
+  }
+  return ok_result();
+}
+
+AnthropicAdaptResult AnthropicStreamEncoder::finish(
+    const llm::RequestOutput& output,
+    std::vector<std::string>* out) {
+  std::vector<xllm::proto::AnthropicStreamEvent> events;
+  add_message_start(output, &events);
+  if (state_.content_block_index >= 0) {
+    add_block_stop(&events);
+    state_.last_content_block_type.clear();
+  }
+
+  std::string finish_reason;
+  for (const auto& seq_output : output.outputs) {
+    if (seq_output.finish_reason.has_value()) {
+      finish_reason = seq_output.finish_reason.value();
+    }
+  }
+  add_message_delta(output, finish_reason, &events);
+  add_message_stop(&events);
+
+  std::string error;
+  if (!append_proto_sse(events, out, &error)) {
+    return error_result(error);
+  }
+  return ok_result();
+}
+
+}  // namespace xllm_service

--- a/xllm_service/http_service/anthropic_stream_encoder.h
+++ b/xllm_service/http_service/anthropic_stream_encoder.h
@@ -84,10 +84,9 @@ class AnthropicStreamEncoder {
   void add_sig_delta(std::vector<xllm::proto::AnthropicStreamEvent>* events);
   void add_block_stop(std::vector<xllm::proto::AnthropicStreamEvent>* events);
   void start_text_block(std::vector<xllm::proto::AnthropicStreamEvent>* events);
-  void start_tool_block(
-      const std::string& tool_call_id,
-      const std::string& function_name,
-      std::vector<xllm::proto::AnthropicStreamEvent>* events);
+  void start_tool_block(const std::string& tool_call_id,
+                        const std::string& function_name,
+                        std::vector<xllm::proto::AnthropicStreamEvent>* events);
   void add_text_delta(const std::string& text,
                       std::vector<xllm::proto::AnthropicStreamEvent>* events);
   void add_message_delta(

--- a/xllm_service/http_service/anthropic_stream_encoder.h
+++ b/xllm_service/http_service/anthropic_stream_encoder.h
@@ -1,0 +1,108 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm-service/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <vector>
+
+#include "common/xllm/output.h"
+#include "http_service/anthropic_adapter.h"
+
+namespace xllm_service {
+
+// Translates a stream of parsed model deltas (reasoning / plain text / tool
+// arguments) into Anthropic Messages SSE events. The encoder owns the whole
+// content-block state machine (block index, block-type transitions, thinking
+// signature, pending tool call); each `on_*` / `finish` call appends 0..N
+// ready-to-write SSE strings to `out` and returns ok/err.
+//
+// Splitting a model chunk into reasoning vs tool vs plain text stays in the
+// orchestration layer; the encoder only consumes already-split deltas and is
+// therefore pure compute (no I/O, no stream_parser dependency).
+class AnthropicStreamEncoder {
+ public:
+  explicit AnthropicStreamEncoder(std::string model);
+
+  AnthropicAdaptResult on_reasoning(const llm::RequestOutput& output,
+                                    const std::string& thinking,
+                                    std::vector<std::string>* out);
+
+  AnthropicAdaptResult on_text(const llm::RequestOutput& output,
+                               const std::string& text,
+                               std::vector<std::string>* out);
+
+  AnthropicAdaptResult on_tool(const llm::RequestOutput& output,
+                               const std::string& tool_call_id,
+                               const std::string& function_name,
+                               const std::string& arguments,
+                               std::vector<std::string>* out);
+
+  AnthropicAdaptResult finish(const llm::RequestOutput& output,
+                              std::vector<std::string>* out);
+
+  // State the orchestration layer reads/writes while deciding how to split an
+  // incoming chunk (reasoning boundary vs tool boundary).
+  bool pending_tool_call() const { return state_.pending_tool_call; }
+  void set_pending_tool_call(bool pending) {
+    state_.pending_tool_call = pending;
+  }
+  const std::string& last_content_block_type() const {
+    return state_.last_content_block_type;
+  }
+
+ private:
+  // Content-block state machine (formerly the public AnthropicStreamState,
+  // now an internal implementation detail of the encoder).
+  struct State {
+    bool message_started = false;
+    bool has_tool_call = false;
+    bool pending_tool_call = false;
+    int32_t content_block_index = -1;
+    std::string last_content_block_type;
+    std::string thinking_signature;
+  };
+
+  // Proto-event builders for the text / tool / finish paths.
+  void add_message_start(
+      const llm::RequestOutput& request_output,
+      std::vector<xllm::proto::AnthropicStreamEvent>* events);
+  void add_sig_delta(std::vector<xllm::proto::AnthropicStreamEvent>* events);
+  void add_block_stop(std::vector<xllm::proto::AnthropicStreamEvent>* events);
+  void start_text_block(std::vector<xllm::proto::AnthropicStreamEvent>* events);
+  void start_tool_block(
+      const std::string& tool_call_id,
+      const std::string& function_name,
+      std::vector<xllm::proto::AnthropicStreamEvent>* events);
+  void add_text_delta(const std::string& text,
+                      std::vector<xllm::proto::AnthropicStreamEvent>* events);
+  void add_message_delta(
+      const llm::RequestOutput& request_output,
+      const std::string& finish_reason,
+      std::vector<xllm::proto::AnthropicStreamEvent>* events);
+  void add_message_stop(std::vector<xllm::proto::AnthropicStreamEvent>* events);
+
+  // Thinking blocks are emitted as raw SSE strings (no proto representation).
+  void start_thinking_block(std::vector<std::string>* sse_events);
+  void add_thinking_delta(const std::string& thinking,
+                          std::vector<std::string>* sse_events);
+
+  std::string model_;
+  State state_;
+};
+
+}  // namespace xllm_service

--- a/xllm_service/http_service/service.cpp
+++ b/xllm_service/http_service/service.cpp
@@ -73,7 +73,8 @@ AnthropicTracer make_anthropic_tracer(const std::shared_ptr<Request>& request) {
     sink = request->trace_callback;
     service_request_id = request->service_request_id;
   }
-  return AnthropicTracer(std::move(sink), /*request_id=*/"", service_request_id);
+  return AnthropicTracer(
+      std::move(sink), /*request_id=*/"", service_request_id);
 }
 
 nlohmann::json proto_value_to_json(const google::protobuf::Value& pb_value);
@@ -713,12 +714,13 @@ void XllmHttpServiceImpl::AnthropicMessages(
   req_pb->mutable_routing()->set_decode_name(
       service_request->routing.decode_name);
 
-  auto call_data = std::make_shared<AnthropicCallData>(cntl,
-                                                       service_request->stream,
-                                                       done_guard.release(),
-                                                       req_pb,
-                                                       resp_pb,
-                                                       service_request->trace_callback);
+  auto call_data =
+      std::make_shared<AnthropicCallData>(cntl,
+                                          service_request->stream,
+                                          done_guard.release(),
+                                          req_pb,
+                                          resp_pb,
+                                          service_request->trace_callback);
   if (!call_data->x_request_id.empty()) {
     req_pb->set_x_request_id(call_data->x_request_id);
   }

--- a/xllm_service/http_service/service.cpp
+++ b/xllm_service/http_service/service.cpp
@@ -28,6 +28,7 @@ limitations under the License.
 #include <nlohmann/json.hpp>
 
 #include "chat.pb.h"
+#include "common/anthropic_tracer.h"
 #include "common/call_data.h"
 #include "common/closure_guard.h"
 #include "common/utils.h"
@@ -50,6 +51,29 @@ std::string generate_service_request_id(const std::string& method) {
   ss << "-";
   ss << short_uuid.random();
   return ss.str();
+}
+
+std::string proto_json(const google::protobuf::Message& message) {
+  std::string json;
+  google::protobuf::util::JsonPrintOptions options;
+  options.add_whitespace = false;
+  options.always_print_primitive_fields = true;
+  auto status =
+      google::protobuf::util::MessageToJsonString(message, &json, options);
+  if (!status.ok()) {
+    return message.DebugString();
+  }
+  return json;
+}
+
+AnthropicTracer make_anthropic_tracer(const std::shared_ptr<Request>& request) {
+  AnthropicTracer::Sink sink;
+  std::string service_request_id;
+  if (request) {
+    sink = request->trace_callback;
+    service_request_id = request->service_request_id;
+  }
+  return AnthropicTracer(std::move(sink), /*request_id=*/"", service_request_id);
 }
 
 nlohmann::json proto_value_to_json(const google::protobuf::Value& pb_value);
@@ -647,8 +671,7 @@ void XllmHttpServiceImpl::AnthropicMessages(
   std::string attachment;
   cntl->request_attachment().copy_to(&attachment, content_len, 0);
 
-  auto parse_result =
-      parse_anthropic_json(std::move(attachment), anthropic_req_pb);
+  auto parse_result = parse_anthropic_json(attachment, anthropic_req_pb);
   if (!parse_result.ok) {
     cntl->SetFailed(parse_result.error);
     LOG(ERROR) << "parse anthropic json failed: " << parse_result.error;
@@ -665,6 +688,10 @@ void XllmHttpServiceImpl::AnthropicMessages(
   req_pb->set_request_id(new_anthropic_id());
 
   auto service_request = generate_request(req_pb, "/v1/messages");
+  auto tracer = make_anthropic_tracer(service_request);
+  tracer.trace("raw_http_request", attachment);
+  tracer.trace("anthropic_request_pb", proto_json(*anthropic_req_pb));
+  tracer.trace("chat_request_after_adapt", proto_json(*req_pb));
   service_request->messages = std::move(messages);
   service_request->tools = parse_tools_from_proto(req_pb->tools());
   if (req_pb->has_tool_choice()) {
@@ -686,8 +713,12 @@ void XllmHttpServiceImpl::AnthropicMessages(
   req_pb->mutable_routing()->set_decode_name(
       service_request->routing.decode_name);
 
-  auto call_data = std::make_shared<AnthropicCallData>(
-      cntl, service_request->stream, done_guard.release(), req_pb, resp_pb);
+  auto call_data = std::make_shared<AnthropicCallData>(cntl,
+                                                       service_request->stream,
+                                                       done_guard.release(),
+                                                       req_pb,
+                                                       resp_pb,
+                                                       service_request->trace_callback);
   if (!call_data->x_request_id.empty()) {
     req_pb->set_x_request_id(call_data->x_request_id);
   }

--- a/xllm_service/scheduler/CMakeLists.txt
+++ b/xllm_service/scheduler/CMakeLists.txt
@@ -54,6 +54,7 @@ cc_library(
     scheduler.cpp
   DEPS
     :anthropic_adapter
+    :anthropic_stream_encoder
     :chat_template
     :common
     :etcd_client

--- a/xllm_service/scheduler/response_handler.cpp
+++ b/xllm_service/scheduler/response_handler.cpp
@@ -52,7 +52,9 @@ size_t find_tool_start(const std::string& text) {
 AnthropicTracer make_anthropic_tracer(
     const std::shared_ptr<AnthropicCallData>& call_data) {
   return AnthropicTracer(
-      [call_data](const std::string& formatted) { call_data->trace(formatted); },
+      [call_data](const std::string& formatted) {
+        call_data->trace(formatted);
+      },
       call_data->request().request_id(),
       call_data->request().service_request_id());
 }
@@ -480,10 +482,10 @@ bool ResponseHandler::send_delta_to_client(
     const auto& index = seq_output.index;
     std::string cur_text = seq_output.text;
     tracer.trace("stream_model_delta",
-                 "index=" + std::to_string(index) + " finished=" +
-                     (output.finished ? "true" : "false") + " finish_reason=" +
-                     seq_output.finish_reason.value_or("") + " text=" +
-                     cur_text);
+                 "index=" + std::to_string(index) +
+                     " finished=" + (output.finished ? "true" : "false") +
+                     " finish_reason=" + seq_output.finish_reason.value_or("") +
+                     " text=" + cur_text);
 
     // Splits a chunk into reasoning (emitted now) and the remaining plain text
     // (accumulated into *normal_text). Reasoning/text encoding is delegated to
@@ -500,9 +502,8 @@ bool ResponseHandler::send_delta_to_client(
       auto* parser = stream_parser->get_reasoning_parser(index);
       auto result = parser->parse_stream_chunk(text);
       if (result.reasoning_text.has_value()) {
-        auto adapt_result =
-            encoder.on_reasoning(output, result.reasoning_text.value(),
-                                 &sse_events);
+        auto adapt_result = encoder.on_reasoning(
+            output, result.reasoning_text.value(), &sse_events);
         if (!adapt_result.ok) {
           return call_data->finish_with_error(adapt_result.error);
         }
@@ -801,10 +802,10 @@ bool ResponseHandler::send_result_to_client(
   std::optional<std::string> reasoning_content;
 
   if (!output.outputs.empty() && !output.outputs.front().text.empty()) {
-    tracer.trace("non_stream_model_output",
-                 "finish_reason=" +
-                     output.outputs.front().finish_reason.value_or("") +
-                     " text=" + output.outputs.front().text);
+    tracer.trace(
+        "non_stream_model_output",
+        "finish_reason=" + output.outputs.front().finish_reason.value_or("") +
+            " text=" + output.outputs.front().text);
     auto parsed = parse_chat_output_with_xllm(
         output.outputs.front().text,
         tools,
@@ -825,11 +826,11 @@ bool ResponseHandler::send_result_to_client(
       parsed_tool_calls = std::move(parsed.tool_calls.value());
       tool_calls = &parsed_tool_calls.value();
     }
-    tracer.trace("non_stream_parsed_output",
-                 "text=" + output.outputs.front().text + " has_reasoning=" +
-                     (reasoning_content.has_value() ? "true" : "false") +
-                     " has_tool_calls=" +
-                     (tool_calls == nullptr ? "false" : "true"));
+    tracer.trace(
+        "non_stream_parsed_output",
+        "text=" + output.outputs.front().text + " has_reasoning=" +
+            (reasoning_content.has_value() ? "true" : "false") +
+            " has_tool_calls=" + (tool_calls == nullptr ? "false" : "true"));
     if (reasoning_content.has_value()) {
       tracer.trace("non_stream_reasoning", reasoning_content.value());
     }

--- a/xllm_service/scheduler/response_handler.cpp
+++ b/xllm_service/scheduler/response_handler.cpp
@@ -17,7 +17,9 @@ limitations under the License.
 
 #include <optional>
 
+#include "common/anthropic_tracer.h"
 #include "http_service/anthropic_adapter.h"
+#include "http_service/anthropic_stream_encoder.h"
 #include "scheduler/xllm_chat_parse_bridge.h"
 #include "xllm/xllm/api_service/stream_output_parser.h"
 #include "xllm/xllm/api_service/utils.h"
@@ -25,6 +27,35 @@ limitations under the License.
 
 namespace xllm_service {
 namespace {
+
+size_t find_tool_start(const std::string& text) {
+  size_t pos = std::string::npos;
+  const std::vector<std::string> markers = {
+      "<tool_call",
+      "<function=",
+      "<|tool_calls_section_begin|>",
+      "<|tool_call_begin|>",
+      "<｜tool▁calls▁begin｜>",
+      "\"tool_calls\"",
+      "'tool_calls'",
+  };
+
+  for (const auto& marker : markers) {
+    size_t marker_pos = text.find(marker);
+    if (marker_pos != std::string::npos && marker_pos < pos) {
+      pos = marker_pos;
+    }
+  }
+  return pos;
+}
+
+AnthropicTracer make_anthropic_tracer(
+    const std::shared_ptr<AnthropicCallData>& call_data) {
+  return AnthropicTracer(
+      [call_data](const std::string& formatted) { call_data->trace(formatted); },
+      call_data->request().request_id(),
+      call_data->request().service_request_id());
+}
 
 void set_logprobs(xllm::proto::ChatChoice* choice,
                   const std::optional<std::vector<llm::LogProb>>& logprobs) {
@@ -195,12 +226,8 @@ ResponseHandler::create_chat_stream_parse_state(
     const std::string& reasoning_parser,
     bool force_reasoning) {
   auto state = std::make_shared<ChatStreamParseState>();
-  state->stream_parser =
-      create_stream_output_parser_with_xllm(tools,
-                                            model,
-                                            tool_call_parser,
-                                            reasoning_parser,
-                                            force_reasoning);
+  state->stream_parser = create_stream_output_parser_with_xllm(
+      tools, model, tool_call_parser, reasoning_parser, force_reasoning);
   return state;
 }
 
@@ -440,9 +467,10 @@ bool ResponseHandler::send_delta_to_client(
     std::shared_ptr<AnthropicCallData> call_data,
     const std::string& model,
     const llm::RequestOutput& output,
-    AnthropicStreamState& stream_state,
+    AnthropicStreamEncoder& encoder,
     std::shared_ptr<xllm::StreamOutputParser> stream_parser) {
-  std::vector<xllm::proto::AnthropicStreamEvent> events;
+  std::vector<std::string> sse_events;
+  auto tracer = make_anthropic_tracer(call_data);
 
   if (stream_parser && !output.outputs.empty()) {
     stream_parser->check_resize_for_index(output.outputs.size() - 1);
@@ -451,16 +479,92 @@ bool ResponseHandler::send_delta_to_client(
   for (const auto& seq_output : output.outputs) {
     const auto& index = seq_output.index;
     std::string cur_text = seq_output.text;
+    tracer.trace("stream_model_delta",
+                 "index=" + std::to_string(index) + " finished=" +
+                     (output.finished ? "true" : "false") + " finish_reason=" +
+                     seq_output.finish_reason.value_or("") + " text=" +
+                     cur_text);
+
+    // Splits a chunk into reasoning (emitted now) and the remaining plain text
+    // (accumulated into *normal_text). Reasoning/text encoding is delegated to
+    // the encoder; only the split decision lives here.
+    auto emit_reasoning = [&](std::string text,
+                              std::string* normal_text) -> bool {
+      if (text.empty() || !stream_parser || !stream_parser->is_reasoning()) {
+        if (normal_text) {
+          *normal_text += text;
+        }
+        return true;
+      }
+
+      auto* parser = stream_parser->get_reasoning_parser(index);
+      auto result = parser->parse_stream_chunk(text);
+      if (result.reasoning_text.has_value()) {
+        auto adapt_result =
+            encoder.on_reasoning(output, result.reasoning_text.value(),
+                                 &sse_events);
+        if (!adapt_result.ok) {
+          return call_data->finish_with_error(adapt_result.error);
+        }
+      }
+      if (normal_text && result.normal_text.has_value()) {
+        *normal_text += result.normal_text.value();
+      }
+      return true;
+    };
+
+    auto emit_text = [&](const std::string& text) -> bool {
+      auto result = encoder.on_text(output, text, &sse_events);
+      if (!result.ok) {
+        return call_data->finish_with_error(result.error);
+      }
+      return true;
+    };
 
     if (!cur_text.empty() && stream_parser && stream_parser->is_tool_call()) {
       auto* parser = stream_parser->get_tool_call_parser(index);
       if (parser) {
-        auto parse_result = parser->parse_streaming_increment(cur_text);
+        std::string tool_text = cur_text;
+        const bool parsing_tool =
+            encoder.pending_tool_call() ||
+            encoder.last_content_block_type() == "tool_use";
+        bool saw_tool_start = find_tool_start(tool_text) != std::string::npos;
+        if (!parsing_tool) {
+          size_t tool_pos = find_tool_start(tool_text);
+          if (tool_pos != std::string::npos) {
+            std::string normal_text;
+            if (!emit_reasoning(tool_text.substr(0, tool_pos), &normal_text)) {
+              return false;
+            }
+            if (!normal_text.empty() && !emit_text(normal_text)) {
+              return false;
+            }
+            tool_text = tool_text.substr(tool_pos);
+            saw_tool_start = true;
+          }
+        }
+        if (!parsing_tool && find_tool_start(tool_text) == std::string::npos) {
+          std::string normal_text;
+          if (!emit_reasoning(tool_text, &normal_text)) {
+            return false;
+          }
+          if (!normal_text.empty() && !emit_text(normal_text)) {
+            return false;
+          }
+          tool_text.clear();
+        }
+        if (saw_tool_start) {
+          encoder.set_pending_tool_call(true);
+        }
+
+        auto parse_result = parser->parse_streaming_increment(tool_text);
         if (!parse_result.normal_text.empty()) {
-          auto result = add_anthropic_text_delta(
-              model, output, parse_result.normal_text, stream_state, events);
-          if (!result.ok) {
-            return call_data->finish_with_error(result.error);
+          std::string normal_text;
+          if (!emit_reasoning(parse_result.normal_text, &normal_text)) {
+            return false;
+          }
+          if (!normal_text.empty() && !emit_text(normal_text)) {
+            return false;
           }
         }
 
@@ -472,25 +576,36 @@ bool ResponseHandler::send_delta_to_client(
           if (call_item.name.has_value()) {
             tool_call_id = xllm::function_call::utils::generate_tool_call_id();
             function_name = call_item.name.value();
+            encoder.set_pending_tool_call(false);
           }
 
-          auto result = add_anthropic_tool_delta(model,
-                                                 output,
-                                                 tool_call_id,
-                                                 function_name,
-                                                 call_item.parameters,
-                                                 stream_state,
-                                                 events);
+          auto result = encoder.on_tool(output,
+                                        tool_call_id,
+                                        function_name,
+                                        call_item.parameters,
+                                        &sse_events);
           if (!result.ok) {
             return call_data->finish_with_error(result.error);
           }
+          if (encoder.last_content_block_type() == "tool_use") {
+            encoder.set_pending_tool_call(false);
+          }
         }
       }
+    } else if (!cur_text.empty() && stream_parser &&
+               stream_parser->is_reasoning()) {
+      std::string normal_text;
+      if (!emit_reasoning(cur_text, &normal_text)) {
+        return false;
+      }
+      // The plain-text remainder after the reasoning boundary must still be
+      // emitted as a text block (the tool branch above does the same).
+      if (!normal_text.empty() && !emit_text(normal_text)) {
+        return false;
+      }
     } else if (!cur_text.empty()) {
-      auto result = add_anthropic_text_delta(
-          model, output, cur_text, stream_state, events);
-      if (!result.ok) {
-        return call_data->finish_with_error(result.error);
+      if (!emit_text(cur_text)) {
+        return false;
       }
     }
 
@@ -498,12 +613,8 @@ bool ResponseHandler::send_delta_to_client(
         stream_parser->get_has_tool_call(index)) {
       auto send_func = [&](const std::string& arguments, int tool_index) {
         (void)tool_index;
-        auto result = add_anthropic_tool_delta(
-            model, output, "", "", arguments, stream_state, events);
-        if (!result.ok) {
-          return false;
-        }
-        return true;
+        auto result = encoder.on_tool(output, "", "", arguments, &sse_events);
+        return result.ok;
       };
       if (!xllm::api_service::check_for_unstreamed_tool_args(
               stream_parser, index, send_func)) {
@@ -513,19 +624,14 @@ bool ResponseHandler::send_delta_to_client(
   }
 
   if (output.finished) {
-    auto result = finish_anthropic_stream(model, output, stream_state, events);
+    auto result = encoder.finish(output, &sse_events);
     if (!result.ok) {
       return call_data->finish_with_error(result.error);
     }
   }
 
-  for (const auto& event : events) {
-    std::string sse;
-    std::string err_msg;
-    if (!anthropic_event_sse(event, &sse, &err_msg)) {
-      LOG(ERROR) << "Anthropic stream event json failed: " << err_msg;
-      return call_data->finish_with_error(err_msg);
-    }
+  for (const auto& sse : sse_events) {
+    tracer.trace("stream_sse", sse);
     if (!call_data->write(sse)) {
       return false;
     }
@@ -686,13 +792,19 @@ bool ResponseHandler::send_result_to_client(
     const std::string& reasoning_parser,
     bool force_reasoning) {
   auto& response = call_data->response();
+  auto tracer = make_anthropic_tracer(call_data);
   llm::RequestOutput output = req_output;
   const google::protobuf::RepeatedPtrField<::xllm::proto::ToolCall>*
       tool_calls = nullptr;
   std::optional<google::protobuf::RepeatedPtrField<::xllm::proto::ToolCall>>
       parsed_tool_calls;
+  std::optional<std::string> reasoning_content;
 
   if (!output.outputs.empty() && !output.outputs.front().text.empty()) {
+    tracer.trace("non_stream_model_output",
+                 "finish_reason=" +
+                     output.outputs.front().finish_reason.value_or("") +
+                     " text=" + output.outputs.front().text);
     auto parsed = parse_chat_output_with_xllm(
         output.outputs.front().text,
         tools,
@@ -706,9 +818,20 @@ bool ResponseHandler::send_result_to_client(
     if (!parsed.finish_reason.empty()) {
       output.outputs.front().finish_reason = std::move(parsed.finish_reason);
     }
+    if (parsed.reasoning_content.has_value()) {
+      reasoning_content = std::move(parsed.reasoning_content.value());
+    }
     if (parsed.tool_calls.has_value()) {
       parsed_tool_calls = std::move(parsed.tool_calls.value());
       tool_calls = &parsed_tool_calls.value();
+    }
+    tracer.trace("non_stream_parsed_output",
+                 "text=" + output.outputs.front().text + " has_reasoning=" +
+                     (reasoning_content.has_value() ? "true" : "false") +
+                     " has_tool_calls=" +
+                     (tool_calls == nullptr ? "false" : "true"));
+    if (reasoning_content.has_value()) {
+      tracer.trace("non_stream_reasoning", reasoning_content.value());
     }
   }
 
@@ -719,10 +842,11 @@ bool ResponseHandler::send_result_to_client(
 
   std::string json_output;
   std::string err_msg;
-  if (!anthropic_json(response, &json_output, &err_msg)) {
+  if (!anthropic_json(response, reasoning_content, &json_output, &err_msg)) {
     LOG(ERROR) << "Anthropic response json failed: " << err_msg;
     return call_data->finish_with_error(err_msg);
   }
+  tracer.trace("non_stream_json_response", json_output);
   return call_data->write_and_finish(json_output);
 }
 

--- a/xllm_service/scheduler/response_handler.h
+++ b/xllm_service/scheduler/response_handler.h
@@ -32,7 +32,7 @@ class StreamOutputParser;
 
 namespace xllm_service {
 
-struct AnthropicStreamState;
+class AnthropicStreamEncoder;
 
 struct ChatStreamParseState {
   std::unordered_set<size_t> first_message_sent;
@@ -81,7 +81,7 @@ class ResponseHandler final {
       std::shared_ptr<AnthropicCallData> call_data,
       const std::string& model,
       const llm::RequestOutput& output,
-      AnthropicStreamState& stream_state,
+      AnthropicStreamEncoder& encoder,
       std::shared_ptr<xllm::StreamOutputParser> stream_parser = nullptr);
   bool send_result_to_client(std::shared_ptr<AnthropicCallData> call_data,
                              const std::string& model,

--- a/xllm_service/scheduler/scheduler.cpp
+++ b/xllm_service/scheduler/scheduler.cpp
@@ -19,6 +19,7 @@ limitations under the License.
 #include "common/utils.h"
 #include "common/xllm/status.h"
 #include "http_service/anthropic_adapter.h"
+#include "http_service/anthropic_stream_encoder.h"
 #include "loadbalance_policy/cache_aware_routing.h"
 #include "loadbalance_policy/round_robin.h"
 #include "loadbalance_policy/slo_aware_policy.h"
@@ -398,8 +399,10 @@ bool Scheduler::record_new_request(std::shared_ptr<AnthropicCallData> call_data,
         request->model, tool_call_parser_pref, reasoning_parser_pref);
     const bool force_reasoning = get_enable_thinking_from_request(
         request->chat_template_kwargs, parser_formats.reasoning_parser);
-    auto stream_state =
-        request->stream ? std::make_shared<AnthropicStreamState>() : nullptr;
+    auto stream_encoder =
+        request->stream
+            ? std::make_shared<AnthropicStreamEncoder>(request->model)
+            : nullptr;
     auto stream_parser =
         request->stream
             ? create_stream_output_parser_with_xllm(tools_for_parse,
@@ -414,7 +417,7 @@ bool Scheduler::record_new_request(std::shared_ptr<AnthropicCallData> call_data,
          call_data,
          model = request->model,
          stream = request->stream,
-         stream_state,
+         stream_encoder,
          stream_parser,
          tools = std::move(tools_for_parse),
          tool_call_parser = std::move(tool_call_parser_pref),
@@ -430,7 +433,7 @@ bool Scheduler::record_new_request(std::shared_ptr<AnthropicCallData> call_data,
 
       if (stream) {
         return response_handler_.send_delta_to_client(
-            call_data, model, req_output, *stream_state, stream_parser);
+            call_data, model, req_output, *stream_encoder, stream_parser);
       } else if (!req_output.finished_on_prefill_instance) {
         return response_handler_.send_result_to_client(call_data,
                                                        model,

--- a/xllm_service/scheduler/xllm_chat_parse_bridge.cpp
+++ b/xllm_service/scheduler/xllm_chat_parse_bridge.cpp
@@ -16,6 +16,7 @@ limitations under the License.
 #include "scheduler/xllm_chat_parse_bridge.h"
 
 #include <absl/strings/ascii.h>
+#include <absl/strings/str_replace.h>
 #include <glog/logging.h>
 
 #include <exception>
@@ -117,6 +118,10 @@ std::string resolve_reasoning_parser(
   return xllm::ReasoningParser::get_parser_auto(reasoning_parser_preference,
                                                 model_type);
 }
+
+std::string strip_think_end(std::string text) {
+  return absl::StrReplaceAll(text, {{"</think>", ""}});
+}
 }  // namespace
 
 bool get_enable_thinking_from_request(
@@ -157,6 +162,50 @@ ChatParseResult parse_chat_output_with_xllm(
 
   const std::string reasoning_parser_format =
       resolve_reasoning_parser(reasoning_parser_preference, model);
+  const std::string parser_format =
+      resolve_tool_call_parser(parser_preference, model);
+
+  if (!tools.empty() && !parser_format.empty() && !result.text.empty()) {
+    auto xllm_tools = to_xllm_tools(tools);
+    xllm::function_call::FunctionCallParser parser(xllm_tools, parser_format);
+
+    if (parser.has_tool_call(result.text)) {
+      if (result.finish_reason == "stop") {
+        result.finish_reason = "tool_calls";
+      }
+
+      try {
+        auto [parsed_text, call_info_list] =
+            parser.parse_non_stream(result.text);
+        result.text = strip_think_end(std::move(parsed_text));
+
+        google::protobuf::RepeatedPtrField<::xllm::proto::ToolCall> tool_calls;
+        for (const auto& call_info : call_info_list) {
+          ::xllm::proto::ToolCall* tool_call =
+              arena ? google::protobuf::Arena::CreateMessage<
+                          ::xllm::proto::ToolCall>(arena)
+                    : new ::xllm::proto::ToolCall();
+
+          tool_call->set_id(
+              xllm::function_call::utils::generate_tool_call_id());
+          tool_call->set_type("function");
+
+          auto* function = tool_call->mutable_function();
+          if (call_info.name.has_value()) {
+            function->set_name(*call_info.name);
+          }
+          function->set_arguments(call_info.parameters);
+
+          tool_calls.AddAllocated(tool_call);
+        }
+
+        result.tool_calls = std::move(tool_calls);
+      } catch (const std::exception& e) {
+        LOG(ERROR) << "Tool call parsing error: " << e.what();
+      }
+    }
+  }
+
   if (!reasoning_parser_format.empty() && !result.text.empty()) {
     try {
       xllm::ReasoningParser reasoning_parser(reasoning_parser_format,
@@ -174,52 +223,6 @@ ChatParseResult parse_chat_output_with_xllm(
     } catch (const std::exception& e) {
       LOG(ERROR) << "Reasoning parsing error: " << e.what();
     }
-  }
-
-  const std::string parser_format =
-      resolve_tool_call_parser(parser_preference, model);
-  if (tools.empty() || parser_format.empty()) {
-    return result;
-  }
-
-  auto xllm_tools = to_xllm_tools(tools);
-  xllm::function_call::FunctionCallParser parser(xllm_tools, parser_format);
-
-  if (!parser.has_tool_call(result.text)) {
-    return result;
-  }
-
-  if (result.finish_reason == "stop") {
-    result.finish_reason = "tool_calls";
-  }
-
-  try {
-    auto [parsed_text, call_info_list] = parser.parse_non_stream(result.text);
-    result.text = std::move(parsed_text);
-
-    google::protobuf::RepeatedPtrField<::xllm::proto::ToolCall> tool_calls;
-    for (const auto& call_info : call_info_list) {
-      ::xllm::proto::ToolCall* tool_call =
-          arena
-              ? google::protobuf::Arena::CreateMessage<::xllm::proto::ToolCall>(
-                    arena)
-              : new ::xllm::proto::ToolCall();
-
-      tool_call->set_id(xllm::function_call::utils::generate_tool_call_id());
-      tool_call->set_type("function");
-
-      auto* function = tool_call->mutable_function();
-      if (call_info.name.has_value()) {
-        function->set_name(*call_info.name);
-      }
-      function->set_arguments(call_info.parameters);
-
-      tool_calls.AddAllocated(tool_call);
-    }
-
-    result.tool_calls = std::move(tool_calls);
-  } catch (const std::exception& e) {
-    LOG(ERROR) << "Tool call parsing error: " << e.what();
   }
 
   return result;

--- a/xllm_service/scheduler/xllm_chat_parse_bridge.h
+++ b/xllm_service/scheduler/xllm_chat_parse_bridge.h
@@ -16,13 +16,13 @@ limitations under the License.
 #pragma once
 
 #include <memory>
+#include <nlohmann/json.hpp>
 #include <optional>
 #include <string>
 #include <vector>
 
 #include "chat.pb.h"
 #include "common/types.h"
-#include <nlohmann/json.hpp>
 
 namespace xllm {
 class StreamOutputParser;


### PR DESCRIPTION
## 概述

本 PR 围绕 **Anthropic `/v1/messages` 接口的 thinking（推理）内容与 tool call（工具调用）处理** 做了一次修复 + 重构，解决三类问题：

1. **请求侧**：Anthropic 入参里的 `thinking` / `redacted_thinking` / `tool_use` 内容块此前会被丢弃或压扁，无法正确还原成下游模型能理解的对话历史。
2. **响应侧（流式 + 非流式）**：模型生成的推理内容没有按 Anthropic 协议封装成 `thinking` 内容块 / SSE 事件，且工具调用与推理文本的边界切分有缺陷。
3. **可维护性**：把散落在 `anthropic_adapter` 里的双份构造逻辑、流式状态机、trace 日志抽成独立模块，并补上大量单元测试。

## 请求路径（Anthropic 请求 → 下游 ChatRequest）

`http_service/anthropic_adapter.cpp` / `.h`：

- **消除"双份构造"**：原来每条消息要同时手工构造 proto `ChatRequest` 和规范 `Message`（两套字段各填一遍，易不一致）。现在统一只构造规范 `Message` 列表，最后通过新模块 `to_proto()` 一次性投影成 proto。
- **新增 thinking 内容块支持**：`add_content_msg` 识别 `thinking` / `redacted_thinking` 块，并把 thinking 文本累加进 `reasoning_content`。
- **保留有序的多模态内容**：用 `ordered_content`（保持 text/thinking/tool_use 原始顺序）替代原先压扁成 `flat_text` 的做法，用 `needs_content_vec()` 决定是否保留结构化内容向量。
- **空 Bash 工具调用过滤**：新增 `is_empty_bash_tool_use()`，跳过无参数的 `Bash` `tool_use` 块（id 记入 `skipped_tool_use_ids`），对应 `tool_result` 一并跳过，避免下游收到无效工具调用 / 孤立结果。

## 响应路径

### 非流式

- `xllm_chat_parse_bridge.cpp`：调整解析顺序为**先 tool call、再 reasoning**；新增 `strip_think_end()` 去掉残留的 `</think>` 标记。
- `response_handler.cpp`（`send_result_to_client`）：取出 `reasoning_content`，通过新增的 `anthropic_json(response, thinking, ...)` 重载把推理内容作为 `thinking` 块插入响应 `content` 数组最前面。
- `anthropic_adapter.cpp`：新增带 thinking 的 `anthropic_json` 重载，用 `new_thinking_sig()` 生成合成 `signature`（仅为兼容占位，**非** Claude 真实校验签名）。

### 流式（重大重构）

- **新增 `anthropic_stream_encoder.h/.cpp`**：把原先 `anthropic_adapter` 里的流式状态机（`AnthropicStreamState` + `add_message_start`/`start_text_block`/`start_tool_block`/`finish_anthropic_stream` 等自由函数）整体抽成 `AnthropicStreamEncoder` 类。它独占内容块状态机（块索引、块类型切换、thinking 签名、pending tool call），对外暴露 `on_reasoning` / `on_text` / `on_tool` / `finish`，新增 `thinking` 块 SSE 事件（thinking → text 切换时补发签名 delta）。
- `anthropic_adapter` 中对应旧流式函数全部删除，`AnthropicStreamState` 移除。
- `response_handler.cpp`（`send_delta_to_client`）：改用 encoder，重写 chunk 切分逻辑。新增 `find_tool_start()` 通过多种标记（`<tool_call`、`<function=`、`<|tool_call_begin|>`、DeepSeek 全角标记、`"tool_calls"` 等）定位工具调用起点，把增量正确切分为「推理 / 普通文本 / 工具参数」三部分，并维护 `pending_tool_call` 状态。
- 新增 `normalize_stream_event_json`：对 `message_start` / `message_delta` 事件 JSON 做规范化（补全 `stop_reason`/`stop_sequence` 为 `null`、写入真实 usage），符合 Anthropic SSE 格式。

## 模板渲染（thinking 进入 prompt）

`chat_template/jinja_chat_template.cpp` / `.h`：

- `Message::MMContent` 新增 `thinking`/`signature`/`data`/`id`/`name`/`input` 字段；`Message` 新增 `reasoning_content`。
- `get_mm_content` 能把 `thinking`/`redacted_thinking`/`tool_use` 块渲染到模板 JSON。
- **thinking 回退机制**：先按原样套用模板，若 prompt 未完整包含所有 thinking 文本（`has_all_thinking` 检查），则用 `with_thinking_fallback()` 把 thinking 块降级为 `<think>...</think>` 纯文本再渲染一次，保证模板不支持 thinking 字段时推理内容不丢失。

## 新增 / 抽取的支撑模块

- `chat_template/message_projection.h/.cpp`（新）：`flat_text()`、`needs_content_vec()`、`to_proto()`——规范 `Message` → proto `ChatMessage` 的单一可信投影路径。
- `common/anthropic_tracer.h/.cpp`（新）：统一 Anthropic 链路的 trace 格式化、`FLAGS_enable_request_trace` 开关与 LOG 上下文（原先 http_service 与 scheduler 各一份）。通过注入 `Sink` 适配生产 / 测试。
- `common/call_data.h`：`StreamCallData` 新增 `trace()` 方法。
- `http_service/service.cpp`：接入 `AnthropicTracer`，请求阶段打点 `raw_http_request` / `anthropic_request_pb` / `chat_request_after_adapt`，并把 `trace_callback` 透传给 `AnthropicCallData`。
- `scheduler/scheduler.cpp` / `response_handler.cpp`：流式状态从 `AnthropicStreamState` 换成 `AnthropicStreamEncoder`，并在各阶段加入 trace 打点（`stream_model_delta`、`stream_sse`、`non_stream_parsed_output`、`non_stream_reasoning` 等）。

## 测试

新增 / 重写单测（CMake 配套接入）：

- `chat_template/message_projection_test.cpp`、`jinja_chat_template_test.cpp`
- `common/anthropic_tracer_test.cpp`
- `http_service/anthropic_adapter_test.cpp`（大幅重写）、`anthropic_stream_encoder_test.cpp`（新）
- `scheduler/xllm_chat_parse_bridge_test.cpp`（新）

## 其他

- `third_party/xllm` 子模块指针更新，指向包含相应解析能力的新 commit。